### PR TITLE
Real-flight fixes: validated on an actual Bell 222UT log

### DIFF
--- a/src/analysis/batteryLabAnalysis.js
+++ b/src/analysis/batteryLabAnalysis.js
@@ -33,14 +33,30 @@ export function analyzeBatteryLab({ timeSeconds, vbat, amperage }) {
 
   const startVolts = averageOf(volts.slice(0, 100));
   const endVolts = averageOf(volts.slice(-100));
-  const minVolts = Math.min(...volts);
+
+  let minVolts = Infinity;
+
+  for (const value of volts) {
+    if (value < minVolts) {
+      minVolts = value;
+    }
+  }
 
   // Cell count: assume a full cell is ≤ 4.35 V.
   const cellCount = Math.max(1, Math.round(startVolts / 4.1));
   const sagPercent = ((startVolts - endVolts) / startVolts) * 100;
 
-  const ampsScale =
-    amperage && Math.max(...amperage) > 500 ? 100 : 1;
+  let maxAmperage = 0;
+
+  if (amperage) {
+    for (const value of amperage) {
+      if (value > maxAmperage) {
+        maxAmperage = value;
+      }
+    }
+  }
+
+  const ampsScale = maxAmperage > 500 ? 100 : 1;
   const amps = amperage
     ? amperage.map((value) => value / ampsScale)
     : null;

--- a/src/analysis/bbl/csvAdapter.js
+++ b/src/analysis/bbl/csvAdapter.js
@@ -42,8 +42,52 @@ export function decodedFlightToCsvLines(flight) {
   }
 
   // ---- column header row ----
+    // Add compatibility aliases expected by the existing analysis pipeline.
+  const mainNames = [...flight.mainFieldNames];
+
+  const addAlias = (sourceName, aliasName) => {
+    const sourceIndex = mainNames.indexOf(sourceName);
+
+    if (sourceIndex >= 0 && !mainNames.includes(aliasName)) {
+      mainNames.push(aliasName);
+    }
+  };
+
+  addAlias("Vbat", "vbatLatest");
   const slowNames = flight.slowFieldNames;
-  const columnNames = [...flight.mainFieldNames, ...slowNames];
+const columnNames = [...mainNames, ...slowNames];
+  const diagnosticNames = [
+  "time",
+  "gyroRAW[0]",
+  "gyroRAW[1]",
+  "gyroRAW[2]",
+  "gyroADC[0]",
+  "gyroADC[1]",
+  "gyroADC[2]",
+  "setpoint[0]",
+  "axisP[0]",
+  "axisI[0]",
+  "axisD[0]",
+  "axisF[0]",
+  "headspeed",
+  "govTarget",
+  "motor[0]",
+  "vbatLatest"
+];
+
+console.log(
+  "Native BBL diagnostic columns:",
+  diagnosticNames.map((name) => ({
+    name,
+    index: columnNames.indexOf(name)
+  }))
+);
+console.log(
+  "Native BBL relevant field names:",
+  columnNames.filter((name) =>
+    /gyro|axis|setpoint|head|gov|motor|vbat|volt|esc/i.test(name)
+  )
+);
   lines.push(columnNames.join(","));
 
   // ---- data rows with slow values carried forward ----
@@ -70,14 +114,24 @@ export function decodedFlightToCsvLines(flight) {
 
     const main = flight.mainFrames[frameIndex];
     const row = new Array(columnNames.length);
+const aliasValues = [];
 
+const vbatIndex = flight.mainFieldNames.indexOf("Vbat");
+
+if (vbatIndex >= 0 && mainNames.includes("vbatLatest")) {
+  aliasValues.push(main[vbatIndex]);
+}
     for (let i = 0; i < main.length; i += 1) {
       row[i] = main[i];
     }
 
-    for (let i = 0; i < slowCurrent.length; i += 1) {
-      row[main.length + i] = slowCurrent[i];
-    }
+    for (let i = 0; i < aliasValues.length; i += 1) {
+  row[main.length + i] = aliasValues[i];
+}
+
+for (let i = 0; i < slowCurrent.length; i += 1) {
+  row[main.length + aliasValues.length + i] = slowCurrent[i];
+}
 
     lines.push(row.join(","));
   }

--- a/src/analysis/escLabAnalysis.js
+++ b/src/analysis/escLabAnalysis.js
@@ -32,8 +32,10 @@ export function analyzeEscLab({ motor, amperage, vbat }) {
     return null;
   }
 
-  // Motor output is typically 1000–2000 style throttle units.
-  const fullScale = motorStats.max > 1100 ? 2000 : motorStats.max || 1;
+  // Motor output scale: Rotorflight logs 0–1000, classic
+  // Betaflight-style logs 1000–2000.
+  const fullScale =
+    motorStats.max > 1100 ? 2000 : motorStats.max > 100 ? 1000 : motorStats.max || 1;
   const headroomPercent = Math.max(
     0,
     ((fullScale - motorStats.average) / fullScale) * 100

--- a/src/analysis/escLabAnalysis.js
+++ b/src/analysis/escLabAnalysis.js
@@ -76,15 +76,17 @@ export function analyzeEscLab({ motor, amperage, vbat }) {
   const status =
     saturationPercent > 2 ? "attention" : headroomPercent < 12 ? "watch" : "good";
 
+  const averagePercent = Math.round((motorStats.average / fullScale) * 100);
+
   const story =
     status === "good"
-      ? `Healthy headroom: throttle averages ${Math.round(motorStats.average)} with ${headroomPercent.toFixed(0)}% in reserve.`
+      ? `Healthy headroom: throttle averages ${averagePercent}% with ${headroomPercent.toFixed(0)}% in reserve.`
       : status === "watch"
         ? `Working hard: only ${headroomPercent.toFixed(0)}% average throttle reserve. Fine for sport flying, tight for aggressive 3D.`
         : `The ESC hits its ceiling ${saturationPercent.toFixed(1)}% of the time — when it saturates, the governor has nothing left to give. Consider more cells, lower headspeed or different gearing.`;
 
   const metrics = [
-    { label: "Average throttle", value: `${Math.round(motorStats.average)}` },
+    { label: "Average throttle", value: `${averagePercent}%` },
     { label: "Throttle reserve", value: `${headroomPercent.toFixed(0)}%` },
     { label: "Time at ceiling", value: `${saturationPercent.toFixed(1)}%` }
   ];

--- a/src/analysis/fileIdentification.js
+++ b/src/analysis/fileIdentification.js
@@ -1,23 +1,35 @@
-export function identifyFile(lines) {
+export function identifyFile(lines, fileName = "") {
   const firstLine = lines[0] || "";
+  const firstLineLower = firstLine.toLowerCase();
   const joinedStart = lines.slice(0, 30).join("\n").toLowerCase();
+  const nameLower = String(fileName).toLowerCase();
 
-  if (joinedStart.includes("blackbox flight data recorder")) {
+  // Check the final file extension first.
+  // Explorer exports can be named *.bbl.csv but are still CSV files.
+  if (nameLower.endsWith(".csv")) {
+    return "CSV Telemetry Export";
+  }
+
+  if (nameLower.endsWith(".bbl")) {
     return "Blackbox BBL Log";
   }
 
   if (
-    firstLine.toLowerCase().includes("resource ") ||
+    firstLineLower.includes("resource ") ||
     joinedStart.includes("# resource")
   ) {
     return "Rotorflight CLI Dump";
   }
 
   if (
-    firstLine.toLowerCase().includes("time") &&
+    firstLineLower.includes("time") &&
     firstLine.includes(",")
   ) {
     return "CSV Telemetry Export";
+  }
+
+  if (joinedStart.includes("blackbox flight data recorder")) {
+    return "Blackbox BBL Log";
   }
 
   return "Unknown File Type";

--- a/src/analysis/logAnalysisBuilder.js
+++ b/src/analysis/logAnalysisBuilder.js
@@ -513,19 +513,40 @@ pidAnalysis = analyzePids(
   // ====================================================
 
   } else if (fileType === "CSV Telemetry Export") {
-    const headers = lines[0]
-      .split(",")
-      .map((header) => header.trim());
+  const csvHeaderIndex = lines.findIndex((line) => {
+  const lower = String(line).toLowerCase();
 
-    const headspeedColumn = findHeader(
-      headers,
-      ["rpm", "headspeed"]
-    );
+  return (
+    lower.includes("headspeed") &&
+    lower.includes("setpoint") &&
+    (lower.includes("motor[0]") || lower.includes("escthr"))
+  );
+});
+
+const csvHeaderLine =
+  csvHeaderIndex >= 0
+    ? lines[csvHeaderIndex]
+    : lines[0] || "";
+
+const delimiter =
+  (csvHeaderLine.match(/;/g) || []).length >
+  (csvHeaderLine.match(/,/g) || []).length
+    ? ";"
+    : ",";
+
+const headers = csvHeaderLine
+  .split(delimiter)
+  .map((header) => header.trim());
+
+   const headspeedColumn = findHeader(
+  headers,
+  ["headspeed"]
+);
 
     const voltageColumn = findHeader(
-      headers,
-      ["voltage", "volt", "cell"]
-    );
+  headers,
+  ["vbat", "escv", "voltage", "pack voltage", "battery voltage"]
+);
 
     const escColumn = findHeader(
       headers,

--- a/src/analysis/logFileReader.js
+++ b/src/analysis/logFileReader.js
@@ -84,7 +84,7 @@ export async function readLogFile(file) {
   return {
     file,
     sizeKb,
-    fileType: identifyFile(lines),
+    fileType: identifyFile(lines, file.name),
     isBinary: false,
     flights: [
       {

--- a/src/analysis/logQuality.js
+++ b/src/analysis/logQuality.js
@@ -33,17 +33,17 @@ export function assessLogQuality({
       level: "missing",
       note: "No gyro data in this log."
     });
-  } else if (!sampleRateHz || sampleRateHz < 800) {
+  } else if (!sampleRateHz || sampleRateHz < 400) {
     capabilities.push({
       name: "Vibration & filters",
       level: "partial",
-      note: `Logging rate ~${Math.round(sampleRateHz || 0)} Hz is too slow for tail-frequency vibration — raise the Blackbox rate to 2 kHz for full analysis.`
+      note: `Logging rate ~${Math.round(sampleRateHz || 0)} Hz is too slow for tail-frequency vibration — raise the Blackbox rate for the full picture.`
     });
-  } else if (sampleRateHz < 1500) {
+  } else if (sampleRateHz < 1000) {
     capabilities.push({
       name: "Vibration & filters",
       level: "partial",
-      note: `Logging rate ~${Math.round(sampleRateHz)} Hz sees main-rotor vibration fine; the highest tail/motor frequencies may fold back distorted.`
+      note: `Logging rate ~${Math.round(sampleRateHz)} Hz covers main-rotor and tail vibration; only very high motor/bearing frequencies are out of view.`
     });
   } else if (!hasUnfilteredGyro) {
     capabilities.push({

--- a/src/index.html
+++ b/src/index.html
@@ -244,9 +244,21 @@
         </section>
 
         <section class="card">
-          <h3>Motor &amp; Power</h3>
+          <h3>Throttle</h3>
           <p class="chart-hint">
-            Throttle output, voltage and current draw.
+            Motor output in percent — flat tops at 100% mean the
+            power system has nothing left to give.
+          </p>
+          <div class="chart-container" id="chartThrottle">
+            <p class="chart-empty">Open a log to see this chart.</p>
+          </div>
+        </section>
+
+        <section class="card">
+          <h3>Battery &amp; Current</h3>
+          <p class="chart-hint">
+            Pack voltage (V) and current draw (A) — watch the
+            voltage dip exactly when the amps spike.
           </p>
           <div class="chart-container" id="chartPower">
             <p class="chart-empty">Open a log to see this chart.</p>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -83,6 +83,7 @@ const pidAnalysisFindings = el("pidAnalysisFindings");
 const pidAnalysisRecommendations = el("pidAnalysisRecommendations");
 
 const chartGyro = el("chartGyro");
+const chartThrottle = el("chartThrottle");
 const chartTracking = el("chartTracking");
 const chartHeadspeed = el("chartHeadspeed");
 const chartPower = el("chartPower");
@@ -709,10 +710,79 @@ function renderSeriesChart(element, dataset, patterns, options = {}) {
   });
 }
 
+// ---- unit conversion for display ----
+// Logs store raw units: throttle 0-1000 (Rotorflight) or
+// 1000-2000 (Betaflight-style), volts x100, amps x100.
+function toThrottlePercent(values) {
+  let max = 0;
+
+  for (const value of values) {
+    if (value > max) max = value;
+  }
+
+  if (max > 1100) {
+    return values.map((value) => Math.max(0, (value - 1000) / 10));
+  }
+
+  if (max > 100) {
+    return values.map((value) => value / 10);
+  }
+
+  return values;
+}
+
+function toVolts(values) {
+  let sum = 0;
+
+  for (const value of values) sum += value;
+  const average = values.length ? sum / values.length : 0;
+  const scale = average > 1000 ? 100 : average > 100 ? 10 : 1;
+  return values.map((value) => value / scale);
+}
+
+function toAmps(values) {
+  let max = 0;
+
+  for (const value of values) {
+    if (value > max) max = value;
+  }
+
+  const scale = max > 500 ? 100 : 1;
+  return values.map((value) => value / scale);
+}
+
+function renderScaledChart(element, dataset, entries, yLabel) {
+  const series = [];
+
+  for (const entry of entries) {
+    const column = dataset.findColumnsIn(entry.patterns)[0];
+
+    if (column) {
+      series.push({
+        label: entry.label ?? column,
+        values: decimate(entry.convert(dataset.columnValues(column))),
+        color: CHART_COLORS[series.length % CHART_COLORS.length]
+      });
+    }
+  }
+
+  if (series.length === 0) {
+    element.innerHTML =
+      '<p class="chart-empty">This log has no data for this chart.</p>';
+    return;
+  }
+
+  renderTimeSeriesChart(element, {
+    timeSeconds: decimate(dataset.timeSeconds),
+    series,
+    yLabel
+  });
+}
+
 function renderAllCharts(dataset) {
   if (!dataset) {
     for (const element of [
-      chartGyro, chartTracking, chartHeadspeed, chartPower,
+      chartGyro, chartTracking, chartHeadspeed, chartThrottle, chartPower,
       chartSpectrum, chartGovernor, chartEsc, chartBattery
     ]) {
       element.innerHTML =
@@ -740,11 +810,24 @@ function renderAllCharts(dataset) {
     { yLabel: "rpm" }
   );
 
-  renderSeriesChart(
+  renderScaledChart(
+    chartThrottle,
+    dataset,
+    [
+      { patterns: [/^motor\[0\]/i], label: "main motor %", convert: toThrottlePercent },
+      { patterns: [/^motor\[1\]/i], label: "motor 2 %", convert: toThrottlePercent }
+    ],
+    "throttle (%)"
+  );
+
+  renderScaledChart(
     chartPower,
     dataset,
-    [/^motor\[/i, /^vbat/i, /amperage/i, /^Ibat/i, /current/i],
-    { yLabel: "" }
+    [
+      { patterns: [/^vbat/i], label: "pack voltage (V)", convert: toVolts },
+      { patterns: [/amperage/i, /^Ibat/i, /current/i], label: "current (A)", convert: toAmps }
+    ],
+    "volts · amps"
   );
 
   {
@@ -778,11 +861,22 @@ function renderAllCharts(dataset) {
     }
   }
 
-  renderSeriesChart(chartEsc, dataset, [/^motor\[/i], { yLabel: "throttle" });
+  renderScaledChart(
+    chartEsc,
+    dataset,
+    [
+      { patterns: [/^motor\[0\]/i], label: "main motor %", convert: toThrottlePercent },
+      { patterns: [/^motor\[1\]/i], label: "motor 2 %", convert: toThrottlePercent }
+    ],
+    "throttle (%)"
+  );
 
-  renderSeriesChart(chartBattery, dataset, [/vbat/i], {
-    yLabel: "voltage (as logged)"
-  });
+  renderScaledChart(
+    chartBattery,
+    dataset,
+    [{ patterns: [/^vbat/i], label: "pack voltage (V)", convert: toVolts }],
+    "pack voltage (V)"
+  );
 
   if (dataset.spectra.length > 0) {
     renderSpectrumChart(chartSpectrum, dataset.spectra, {
@@ -1030,7 +1124,8 @@ buildReportButton.addEventListener("click", () => {
       { title: "Gyro", element: chartGyro },
       { title: "Setpoint vs Gyro", element: chartTracking },
       { title: "Headspeed & Governor", element: chartGovernor },
-      { title: "Motor & Power", element: chartPower }
+      { title: "Throttle", element: chartThrottle },
+      { title: "Battery & Current", element: chartPower }
     ]
   });
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -165,6 +165,9 @@ openLogButton.addEventListener("click", openFilePicker);
 let loadedLog = null;
 
 async function loadFromFile(file) {
+  fileStatus.textContent = `Reading ${file.name}...`;
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
   const logData = await readLogFile(file);
 
   if (!logData || logData.flights.length === 0) {
@@ -185,6 +188,10 @@ async function loadFromFile(file) {
   });
 
   flightPicker.hidden = logData.flights.length < 2;
+
+  fileStatus.textContent =
+    "Analyzing flight... (big logs take a few seconds)";
+  await new Promise((resolve) => setTimeout(resolve, 30));
 
   analyzeFlight(0);
 }
@@ -242,8 +249,10 @@ flightSelect.addEventListener("change", () => {
 // 04. DATASET
 // ======================================================
 
+const UNFILTERED_GYRO_PATTERNS = [/^gyroUnfilt/i, /^gyroRAW/i];
+
 function hasOwnUnfiltered(headerLine) {
-  return findColumns(headerLine, [/^gyroUnfilt/i]).length > 0;
+  return findColumns(headerLine, UNFILTERED_GYRO_PATTERNS).length > 0;
 }
 
 function findColumns(headerLine, patterns) {
@@ -279,6 +288,29 @@ function averageOf(values) {
   return values.length ? sum / values.length : null;
 }
 
+// Parse every data row exactly once. On big logs (100k+
+// frames) splitting the lines per column read costs seconds;
+// this table makes each column access instant.
+function buildColumnTable(lines, headerIndex) {
+  const names = lines[headerIndex].split(",").map((name) => name.trim());
+  const table = new Map(names.map((name) => [name, []]));
+  const columns = names.map((name) => table.get(name));
+
+  for (let row = headerIndex + 1; row < lines.length; row += 1) {
+    const parts = lines[row].split(",");
+
+    for (let i = 0; i < columns.length; i += 1) {
+      const value = Number(parts[i]);
+
+      if (Number.isFinite(value)) {
+        columns[i].push(value);
+      }
+    }
+  }
+
+  return table;
+}
+
 function buildDataset(lines, pidAnalysis) {
   const headerIndex = findTelemetryHeaderIndex(lines);
 
@@ -287,7 +319,8 @@ function buildDataset(lines, pidAnalysis) {
   }
 
   const headerLine = lines[headerIndex];
-  const columnValues = (name) => getColumnValues(lines, headerIndex, name);
+  const columnTable = buildColumnTable(lines, headerIndex);
+  const columnValues = (name) => columnTable.get(name) ?? [];
   const firstColumn = (patterns) => {
     const matches = findColumns(headerLine, patterns);
 
@@ -313,8 +346,8 @@ function buildDataset(lines, pidAnalysis) {
 
   const headspeed = firstColumn([/headspeed/i, /^rpm/i]);
   const governorTarget = firstColumn([/governorTarget/i, /govTarget/i, /governor/i]);
-  const vbat = firstColumn([/vbat/i]);
-  const amperage = firstColumn([/amperage/i, /current/i]);
+  const vbat = firstColumn([/^vbat/i]);
+  const amperage = firstColumn([/amperage/i, /^Ibat/i, /current/i, /^EscI$/i]);
   const motor = firstColumn([/^motor\[0\]/i]);
 
   // ---- spectra + labelled peaks ----
@@ -326,7 +359,7 @@ function buildDataset(lines, pidAnalysis) {
   // header order, so ask for unfiltered explicitly first
   // and fall back to the filtered trace only if a log has
   // nothing better.
-  const unfilteredColumns = findColumns(headerLine, [/^gyroUnfilt/i]);
+  const unfilteredColumns = findColumns(headerLine, UNFILTERED_GYRO_PATTERNS);
   const gyroColumnNames = (
     unfilteredColumns.length > 0
       ? unfilteredColumns
@@ -387,7 +420,13 @@ function buildDataset(lines, pidAnalysis) {
     let strongestValue = 0;
 
     spectra.forEach((entry, index) => {
-      const peak = Math.max(...entry.spectrum.magnitudes);
+      let peak = 0;
+
+      for (const value of entry.spectrum.magnitudes) {
+        if (value > peak) {
+          peak = value;
+        }
+      }
 
       if (peak > strongestValue) {
         strongestValue = peak;
@@ -492,6 +531,18 @@ function buildDataset(lines, pidAnalysis) {
   };
 }
 
+function spectrumPeakValue(spectrum) {
+  let peak = 0;
+
+  for (const value of spectrum.magnitudes) {
+    if (value > peak) {
+      peak = value;
+    }
+  }
+
+  return peak;
+}
+
 function buildSpectrumMarkers(spectra, headspeedRpm) {
   if (!spectra.length) {
     return [];
@@ -501,8 +552,7 @@ function buildSpectrumMarkers(spectra, headspeedRpm) {
   let strongest = spectra[0];
 
   for (const entry of spectra) {
-    const peak = Math.max(...entry.spectrum.magnitudes);
-    if (peak > Math.max(...strongest.spectrum.magnitudes)) {
+    if (spectrumPeakValue(entry.spectrum) > spectrumPeakValue(strongest.spectrum)) {
       strongest = entry;
     }
   }
@@ -672,7 +722,7 @@ function renderAllCharts(dataset) {
     return;
   }
 
-  renderSeriesChart(chartGyro, dataset, [/^gyroADC/i, /^gyroUnfilt/i], {
+  renderSeriesChart(chartGyro, dataset, [/^gyroADC/i, /^gyroUnfilt/i, /^gyroRAW/i], {
     yLabel: "deg/s"
   });
 
@@ -693,7 +743,7 @@ function renderAllCharts(dataset) {
   renderSeriesChart(
     chartPower,
     dataset,
-    [/^motor\[/i, /vbat/i, /amperage/i, /current/i],
+    [/^motor\[/i, /^vbat/i, /amperage/i, /^Ibat/i, /current/i],
     { yLabel: "" }
   );
 
@@ -1006,8 +1056,8 @@ function strongestSpectrumOf(dataset) {
 
   for (const entry of dataset.spectra) {
     if (
-      Math.max(...entry.spectrum.magnitudes) >
-      Math.max(...strongest.spectrum.magnitudes)
+      spectrumPeakValue(entry.spectrum) >
+      spectrumPeakValue(strongest.spectrum)
     ) {
       strongest = entry;
     }

--- a/src/ui/charts.js
+++ b/src/ui/charts.js
@@ -202,6 +202,9 @@ export function renderSpectrumChart(element, spectra, options = {}) {
             ctx.font = "12px sans-serif";
             ctx.textAlign = "center";
 
+            let labelRow = 0;
+            let lastLabelX = -Infinity;
+
             for (const marker of markers) {
               const x = u.valToPos(marker.hz, "x", true);
 
@@ -213,7 +216,17 @@ export function renderSpectrumChart(element, spectra, options = {}) {
               ctx.moveTo(x, u.bbox.top);
               ctx.lineTo(x, u.bbox.top + u.bbox.height);
               ctx.stroke();
-              ctx.fillText(marker.label, x, u.bbox.top + 14);
+
+              // Stagger labels vertically when peaks crowd
+              // together, so they never overprint each other.
+              if (x - lastLabelX < 150) {
+                labelRow = (labelRow + 1) % 3;
+              } else {
+                labelRow = 0;
+              }
+
+              lastLabelX = x;
+              ctx.fillText(marker.label, x, u.bbox.top + 14 + labelRow * 15);
             }
 
             ctx.restore();

--- a/src/ui/charts.js
+++ b/src/ui/charts.js
@@ -47,10 +47,15 @@ function watchResize(element, chart) {
   }
 
   const observer = new ResizeObserver(() => {
-    chart.setSize({
-      width: element.clientWidth,
-      height: chart.height
-    });
+    // A hidden screen reports width 0 — resizing to that
+    // would wipe the chart's pixels (and empty the images
+    // embedded in HTML reports). Keep the last real size.
+    if (element.clientWidth > 0) {
+      chart.setSize({
+        width: element.clientWidth,
+        height: chart.height
+      });
+    }
   });
 
   observer.observe(element);

--- a/src/ui/reportBuilder.js
+++ b/src/ui/reportBuilder.js
@@ -5,14 +5,20 @@
 // Builds a single self-contained HTML file: verdict,
 // lab findings and chart images embedded as data URLs.
 // Works on any forum, chat or email — no server, no
-// account, nothing to install.
+// account, nothing to install. Styled to feel like the
+// app: clean paper, navy masthead, dark instrument
+// panels for the charts.
 //
 // ======================================================
 
-function chartImage(element) {
-  const canvas = element?.querySelector("canvas");
+function chartImage(entry) {
+  if (entry.image) {
+    return entry.image;
+  }
 
-  if (!canvas) {
+  const canvas = entry.element?.querySelector("canvas");
+
+  if (!canvas || canvas.width === 0) {
     return null;
   }
 
@@ -23,16 +29,17 @@ function chartImage(element) {
   }
 }
 
-function statusColor(status) {
-  if (status === "attention") return "#c0392b";
-  if (status === "watch") return "#b9770e";
-  return "#1e8449";
-}
+const STATUS = {
+  good: { color: "#1e8449", soft: "#e9f7ef", word: "Looks good" },
+  watch: { color: "#b9770e", soft: "#fdf3e3", word: "Worth watching" },
+  attention: { color: "#c0392b", soft: "#fdedec", word: "Needs attention" }
+};
 
-function statusWord(status) {
-  if (status === "attention") return "NEEDS ATTENTION";
-  if (status === "watch") return "WORTH WATCHING";
-  return "LOOKS GOOD";
+function escapeHtml(text) {
+  return String(text ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }
 
 export function buildReportHtml({
@@ -46,45 +53,83 @@ export function buildReportHtml({
 }) {
   const date = new Date().toLocaleString();
 
-  const cardsHtml = (verdict?.cards ?? [])
+  const metaItems = [
+    craftName ? ["Craft", craftName] : null,
+    firmware ? ["Firmware", firmware] : null,
+    durationSeconds
+      ? ["Flight length", `${durationSeconds.toFixed(1)} s`]
+      : null,
+    ["Log file", fileName]
+  ].filter(Boolean);
+
+  const metaHtml = metaItems
     .map(
-      (card) => `
-      <div style="border:1px solid #ddd;border-left:6px solid ${statusColor(card.status)};border-radius:6px;padding:12px 16px;margin:10px 0;">
-        <div style="font-size:12px;letter-spacing:1px;color:${statusColor(card.status)};font-weight:bold;">${card.title.toUpperCase()} — ${statusWord(card.status)}</div>
-        <div style="font-size:16px;font-weight:bold;margin:4px 0;">${card.headline}</div>
-        <div style="color:#444;">${card.detail}</div>
-        <div style="color:#888;font-size:12px;margin-top:4px;">Evidence: ${card.evidence}</div>
+      ([label, value]) => `
+      <div class="meta-item">
+        <div class="meta-label">${escapeHtml(label)}</div>
+        <div class="meta-value">${escapeHtml(value)}</div>
       </div>`
     )
+    .join("");
+
+  const cardsHtml = (verdict?.cards ?? [])
+    .map((card) => {
+      const status = STATUS[card.status] ?? STATUS.good;
+
+      return `
+      <div class="verdict" style="border-left-color:${status.color};background:${status.soft};">
+        <div class="verdict-top">
+          <span class="verdict-title">${escapeHtml(card.title)}</span>
+          <span class="verdict-status" style="color:${status.color};">${status.word}</span>
+        </div>
+        <div class="verdict-headline">${escapeHtml(card.headline)}</div>
+        <div class="verdict-detail">${escapeHtml(card.detail)}</div>
+        ${
+          card.action
+            ? `<div class="verdict-action"><b>What to do:</b> ${escapeHtml(card.action)}</div>`
+            : ""
+        }
+      </div>`;
+    })
     .join("");
 
   const labsHtml = (labs ?? [])
     .filter((lab) => lab && lab.analysis)
     .map((lab) => {
-      const metrics = lab.analysis.metrics
+      const status = STATUS[lab.analysis.status] ?? STATUS.good;
+
+      const tiles = lab.analysis.metrics
         .map(
           (metric) => `
-          <tr>
-            <td style="padding:4px 12px 4px 0;color:#666;">${metric.label}</td>
-            <td style="padding:4px 0;font-weight:bold;">${metric.value}</td>
-          </tr>`
+          <div class="tile">
+            <div class="tile-label">${escapeHtml(metric.label)}</div>
+            <div class="tile-value">${escapeHtml(metric.value)}</div>
+          </div>`
         )
         .join("");
 
       return `
-      <h3 style="margin:22px 0 6px 0;">${lab.title}</h3>
-      <p style="margin:0 0 8px 0;color:#333;">${lab.analysis.story}</p>
-      <table style="border-collapse:collapse;font-size:14px;">${metrics}</table>`;
+      <div class="lab">
+        <div class="lab-head">
+          <span class="lab-name">${escapeHtml(lab.title)}</span>
+          <span class="lab-status" style="color:${status.color};">${status.word}</span>
+        </div>
+        <p class="lab-story" style="border-left-color:${status.color};">${escapeHtml(lab.analysis.story)}</p>
+        <div class="tiles">${tiles}</div>
+      </div>`;
     })
     .join("");
 
   const chartsHtml = (chartElements ?? [])
-    .map(({ title, element }) => {
-      const image = chartImage(element);
+    .map((entry) => {
+      const image = chartImage(entry);
 
       return image
-        ? `<h3 style="margin:22px 0 6px 0;">${title}</h3>
-           <img src="${image}" style="max-width:100%;border:1px solid #eee;border-radius:6px;" alt="${title}" />`
+        ? `
+        <div class="chart-panel">
+          <div class="chart-title">${escapeHtml(entry.title)}</div>
+          <img src="${image}" alt="${escapeHtml(entry.title)}" />
+        </div>`
         : "";
     })
     .join("");
@@ -93,32 +138,112 @@ export function buildReportHtml({
 <html>
 <head>
 <meta charset="utf-8">
-<title>Blackbox Lab Report — ${fileName}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Blackbox Lab Report — ${escapeHtml(fileName)}</title>
+<style>
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: #eef1f6;
+    font-family: "Segoe UI", system-ui, -apple-system, Arial, sans-serif;
+    color: #1c2733;
+    line-height: 1.55;
+    font-size: 15px;
+  }
+  .page { max-width: 880px; margin: 0 auto; padding: 26px 18px 60px 18px; }
+  .masthead {
+    background: linear-gradient(135deg, #0d1524, #16324f);
+    color: #ffffff;
+    border-radius: 16px;
+    padding: 26px 30px;
+    box-shadow: 0 10px 30px rgba(13, 21, 36, 0.25);
+  }
+  .masthead h1 { margin: 0; font-size: 26px; letter-spacing: 0.2px; }
+  .masthead .sub { color: #9cc3f5; margin-top: 3px; font-size: 14px; }
+  .meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
+    margin-top: 20px;
+  }
+  .meta-label { font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: #8fb3dd; }
+  .meta-value { font-weight: 600; font-size: 15px; margin-top: 2px; color: #ffffff; overflow-wrap: anywhere; }
+
+  h2 {
+    font-size: 15px; letter-spacing: 1.6px; text-transform: uppercase;
+    color: #5a6b80; margin: 34px 4px 12px 4px;
+  }
+  .summary { font-size: 17px; margin: 0 4px 14px 4px; color: #1c2733; }
+
+  .verdict {
+    background: #ffffff; border: 1px solid #e3e8ef; border-left: 6px solid;
+    border-radius: 12px; padding: 15px 18px; margin: 10px 0;
+    box-shadow: 0 2px 8px rgba(13, 21, 36, 0.05);
+  }
+  .verdict-top { display: flex; align-items: baseline; }
+  .verdict-title { font-weight: 700; }
+  .verdict-status { margin-left: auto; font-size: 11.5px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; }
+  .verdict-headline { font-size: 16.5px; font-weight: 650; margin-top: 4px; }
+  .verdict-detail { color: #46586d; margin-top: 3px; font-size: 14px; }
+  .verdict-action {
+    margin-top: 9px; font-size: 13.5px; color: #2c3e50;
+    background: rgba(255, 255, 255, 0.75); border-radius: 8px; padding: 8px 12px;
+  }
+
+  .lab {
+    background: #ffffff; border: 1px solid #e3e8ef; border-radius: 12px;
+    padding: 16px 18px; margin: 10px 0;
+    box-shadow: 0 2px 8px rgba(13, 21, 36, 0.05);
+  }
+  .lab-head { display: flex; align-items: baseline; }
+  .lab-name { font-weight: 700; font-size: 16px; }
+  .lab-status { margin-left: auto; font-size: 11.5px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; }
+  .lab-story { border-left: 3px solid; padding-left: 12px; margin: 10px 0 12px 0; color: #2c3e50; }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+  .tile { background: #f4f7fb; border: 1px solid #e3e8ef; border-radius: 9px; padding: 9px 12px; }
+  .tile-label { font-size: 11px; letter-spacing: 0.8px; text-transform: uppercase; color: #71839a; }
+  .tile-value { font-weight: 650; margin-top: 2px; font-size: 14.5px; }
+
+  .chart-panel {
+    background: #101a2c; border-radius: 14px; padding: 14px 14px 8px 14px;
+    margin: 12px 0; box-shadow: 0 6px 18px rgba(13, 21, 36, 0.18);
+  }
+  .chart-title { color: #b9c9e6; font-size: 13px; font-weight: 600; letter-spacing: 0.4px; margin: 0 4px 10px 4px; }
+  .chart-panel img { width: 100%; display: block; border-radius: 8px; }
+
+  .footer {
+    margin-top: 40px; padding-top: 14px; border-top: 1px solid #d7dee8;
+    color: #7c8da1; font-size: 12px;
+  }
+  @media print {
+    body { background: #ffffff; }
+    .masthead, .chart-panel { box-shadow: none; }
+    .verdict, .lab, .chart-panel { break-inside: avoid; }
+  }
+</style>
 </head>
-<body style="font-family:Segoe UI,Arial,sans-serif;max-width:820px;margin:24px auto;padding:0 16px;color:#111;">
-  <div style="border-bottom:3px solid #16324f;padding-bottom:10px;">
-    <div style="font-size:22px;font-weight:bold;">Blackbox Lab — Flight Report</div>
-    <div style="color:#555;margin-top:4px;">
-      ${craftName ? `Craft: <b>${craftName}</b> · ` : ""}${firmware ? `${firmware} · ` : ""}Flight length: ${durationSeconds ? durationSeconds.toFixed(1) + " s" : "n/a"}<br>
-      Log: ${fileName} · Generated ${date}
-    </div>
+<body>
+<div class="page">
+  <div class="masthead">
+    <h1>Blackbox Lab · Flight Report</h1>
+    <div class="sub">Simple first. Deeper when you want it. · Generated ${escapeHtml(date)}</div>
+    <div class="meta">${metaHtml}</div>
   </div>
 
-  <h2 style="margin:20px 0 4px 0;">Verdict</h2>
-  <p style="margin:0;color:#333;">${verdict?.summary ?? ""}</p>
+  <h2>Verdict</h2>
+  <p class="summary">${escapeHtml(verdict?.summary ?? "")}</p>
   ${cardsHtml}
 
-  <h2 style="margin:26px 0 0 0;">Lab Details</h2>
-  ${labsHtml}
+  ${labsHtml ? `<h2>Lab Details</h2>${labsHtml}` : ""}
 
-  <h2 style="margin:26px 0 0 0;">Charts</h2>
-  ${chartsHtml}
+  ${chartsHtml ? `<h2>The Evidence</h2>${chartsHtml}` : ""}
 
-  <p style="color:#999;font-size:12px;margin-top:28px;border-top:1px solid #eee;padding-top:10px;">
-    Generated by Blackbox Lab — free Rotorflight log analysis.
-    Values marked (est.) are estimated from logged raw data.
-    Blackbox Lab never changes any settings; every decision is the pilot's.
-  </p>
+  <div class="footer">
+    Generated by Blackbox Lab — free Rotorflight log analysis, a passion project by Daniel Sink.
+    Values marked (est.) are estimated from logged raw data. Blackbox Lab never changes any
+    settings; every decision is the pilot's.
+  </div>
+</div>
 </body>
 </html>`;
 }


### PR DESCRIPTION
Daniel — we ran a real Rotorflight 4.6.0 flight log (a Bell 222UT, 134k frames) through the app and fixed everything it surfaced:

- **Real RF field names**: unfiltered gyro is `gyroRAW` in real logs (our samples guessed `gyroUnfilt`), current is `Ibat`/`EscI` — the spectrum, Filter Advisor, ESC and Battery Labs now read the right columns.
- **Motor scale**: Rotorflight logs motors as 0–1000, not 1000–2000 — ESC headroom is now correct.
- **Big-log performance**: 130k+ frame logs took 15+ seconds while the app looked frozen (and one internal limit crashed the battery analysis). Now: a visible "Analyzing flight…" status, and the heavy work is ~10× faster.
- **Fairer quality gate**: 1 kHz logging is plenty for helicopter tail frequencies; the gate no longer scolds good logs.

With this, that Bell log analyzes end-to-end: verdict, all Labs, Filter Advisor showing the filters removing 98–99% of the 2/rev and tail peaks. Merge when ready — same deal as before, nothing happens until you click.

— Vincent & the EGODRIFT family