### PR TITLE
Fix the Linux package build (the red X on the v0.3.0 release)

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -18,11 +18,21 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-deb',
-      config: {},
+      config: {
+        options: {
+          // The packaged binary is named after productName; without
+          // this the installer looks for "blackbox-lab" and fails.
+          bin: 'Blackbox Lab',
+        },
+      },
     },
     {
       name: '@electron-forge/maker-rpm',
-      config: {},
+      config: {
+        options: {
+          bin: 'Blackbox Lab',
+        },
+      },
     },
   ],
   plugins: [


### PR DESCRIPTION
Congrats on shipping v0.3.0, Daniel! 🎉 The Windows installer and the Mac build are on your release and working — nothing to redo there.

You may have noticed the release build shows a red ❌ — that was only the **Linux** part: the Linux installer tooling was looking for the app binary under the wrong name, so the .deb/.rpm packages for Linux users never got built. One tiny config change fixes it (I built and installed the .deb on a Linux machine to make sure).

**What to do:** just scroll down and hit the green **Merge pull request** button. Nothing else — no new release needed right now. The next time you publish a release (v0.3.1, v0.4.0, whenever there's something new), the build will come out fully green with Linux packages included alongside the Windows and Mac ones.