### PR TITLE
Community flight-data sharing (opt-in, anonymized) + about/disclaimer

### DIFF
--- a/Documentation/CONTRIBUTED-DATA.md
+++ b/Documentation/CONTRIBUTED-DATA.md
@@ -1,0 +1,43 @@
+# Contributed flight data — what is shared, exactly
+
+Blackbox Lab can (with the pilot's consent) share an anonymized copy
+of the logs it analyzes. This data helps improve the analysis and
+suggestions for everyone. This document is the complete, honest
+description of what leaves the pilot's machine.
+
+## The rules
+
+1. **Off until asked.** The app asks once, on first launch. "No
+   thanks" turns it off; nothing is ever sent. The choice can be
+   changed anytime in Settings.
+2. **Allowlist, not blocklist.** Only fields explicitly listed in
+   `src/contribute/contributionBuilder.js` are included. Anything
+   unknown is dropped by default — including future fields the
+   firmware might add.
+3. **Never included, in any configuration:**
+   - pilot names or accounts (the app doesn't know them)
+   - log dates and times
+   - board information / serial numbers
+   - absolute GPS coordinates — see below
+4. **The pilot picks categories:**
+   - *Core flight data* (always, when sharing is on): gyro,
+     setpoint, PID terms, motor/servo outputs, headspeed.
+   - *Battery & ESC* (optional): voltage, current, ESC telemetry.
+   - *GPS* (optional, off by default): reduced to a RELATIVE track —
+     every coordinate becomes an offset in meters from the first fix
+     of that flight, plus speed and heading. The flight's shape and
+     speeds survive; where it happened does not.
+   - *Model & tuning* (optional): craft model name and tuning values
+     (filters, governor, PIDs) so logs can be grouped by setup type.
+5. **Private storage.** Contributed logs go to the project's private
+   ingest endpoint and are used only to improve this tool. They are
+   not published or passed on.
+
+## Verifying this
+
+The privacy rules are enforced by tests
+(`test/contribution.test.mjs`) that build payloads from a synthetic
+flight containing deliberately sensitive values (a real city-center
+coordinate, a serial number, a log date, a pilot-named craft) and
+assert they never appear in the output. If a change breaks a rule,
+the test suite fails.

--- a/Documentation/ingest-endpoint-setup.md
+++ b/Documentation/ingest-endpoint-setup.md
@@ -1,0 +1,61 @@
+# Setting up the log ingest endpoint (all in the browser)
+
+The app's "share anonymized logs" feature needs one small piece of
+infrastructure: an address it can send contributed logs to. This
+guide sets one up on Cloudflare's free tier — no coding tools
+needed, everything happens on the Cloudflare website.
+
+The feature stays completely dormant in the app until the address
+is filled in (step 4), so there's no rush: the app works fine
+without it.
+
+## Step 1 — Create a Cloudflare account (if you don't have one)
+
+Go to dash.cloudflare.com, sign up (free plan is plenty).
+
+## Step 2 — Create the storage bucket
+
+1. In the left sidebar: **R2 Object Storage** → **Create bucket**.
+2. Name it `blackbox-logs`, leave everything else default, create.
+   (Buckets are PRIVATE by default — only you can read them.
+   Free tier includes 10 GB, which holds thousands of logs.)
+
+## Step 3 — Create the worker (the receiving address)
+
+1. Left sidebar: **Workers & Pages** → **Create** → **Worker**.
+2. Name it `blackbox-ingest`, deploy the hello-world it suggests.
+3. Click **Edit code**, delete everything, and paste the whole
+   contents of `Documentation/ingest-worker.js` from this repo.
+   Click **Deploy**.
+4. Back on the worker's page: **Settings** → **Bindings** →
+   **Add binding** → **R2 bucket**. Variable name: `LOGS`,
+   bucket: `blackbox-logs`. Save.
+5. The worker's address is shown at the top — something like
+   `https://blackbox-ingest.<your-name>.workers.dev`. Copy it.
+
+## Step 4 — Tell the app about it
+
+In the repo, edit `src/contribute/config.js` (this can be done on
+GitHub in the browser: open the file, click the pencil) and put the
+worker address between the quotes:
+
+    export const CONTRIBUTE_ENDPOINT =
+      "https://blackbox-ingest.<your-name>.workers.dev";
+
+Commit the change and publish a new release — from that version on,
+the app asks pilots on first launch and contributed logs start
+arriving in your bucket.
+
+## Reading the collected logs
+
+R2 → `blackbox-logs` → files are grouped by date, one JSON file
+(gzipped) per contributed flight. Download from the browser, or ask
+for tooling to analyze them in bulk once there's a pile.
+
+## Costs and abuse
+
+Free tier: 10 GB storage, 1M requests/day — hobby scale fits with
+huge room. The worker accepts at most 40 MB per upload and stores
+nothing about the sender (no IP, no account) — the payload is all
+there is. If someone ever abuses the address, rotating it is:
+rename the worker, update config.js, release.

--- a/Documentation/ingest-worker.js
+++ b/Documentation/ingest-worker.js
@@ -1,0 +1,38 @@
+// ======================================================
+// BLACKBOX LAB — LOG INGEST WORKER (Cloudflare)
+//
+// Paste-ready Cloudflare Worker: accepts contributed
+// logs from the app and stores them in a private R2
+// bucket. Setup guide: ingest-endpoint-setup.md
+// ======================================================
+
+const MAX_BODY_BYTES = 40 * 1024 * 1024; // 40 MB gzipped
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("Blackbox Lab ingest", { status: 200 });
+    }
+
+    const length = Number(request.headers.get("Content-Length") || 0);
+    if (length > MAX_BODY_BYTES) {
+      return new Response("too large", { status: 413 });
+    }
+
+    const body = await request.arrayBuffer();
+    if (body.byteLength === 0 || body.byteLength > MAX_BODY_BYTES) {
+      return new Response("bad body", { status: 400 });
+    }
+
+    // Object key: date prefix + random id. No IP, no
+    // user identifier — the payload is all there is.
+    const id = crypto.randomUUID();
+    const day = new Date().toISOString().slice(0, 10);
+    const gzipped =
+      request.headers.get("Content-Encoding") === "gzip" ? ".gz" : "";
+
+    await env.LOGS.put(`${day}/${id}.json${gzipped}`, body);
+
+    return new Response("thanks", { status: 200 });
+  }
+};

--- a/src/contribute/config.js
+++ b/src/contribute/config.js
@@ -1,0 +1,14 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION CONFIG
+//
+// The community ingest endpoint. Leave EMPTY to keep the
+// whole sharing feature dormant (no ask, no uploads) —
+// fill it in once the endpoint exists. Setup guide:
+// Documentation/ingest-endpoint-setup.md
+// ======================================================
+
+export const CONTRIBUTE_ENDPOINT = "";
+
+// Reported inside the payload so contributed logs can be
+// grouped by app version. Update alongside package.json.
+export const CONTRIBUTE_APP_VERSION = "0.3.0";

--- a/src/contribute/contributionBuilder.js
+++ b/src/contribute/contributionBuilder.js
@@ -1,0 +1,198 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION BUILDER
+//
+// Turns a decoded flight into the anonymized payload that
+// "Share anonymized logs" uploads. Strict ALLOWLIST design:
+// nothing leaves the machine unless a rule here names it.
+//
+// Privacy properties (tested in test/contribution.test.mjs):
+//   - no craft name unless the Setup category is enabled
+//   - no board information, no log date/time, ever
+//   - GPS is opt-in and RELATIVE only: track shape, speed
+//     and altitude survive; the pilot's location does not
+//   - unknown/unlisted fields are dropped, not forwarded
+// ======================================================
+
+const CORE_MAIN_FIELDS =
+  /^(time|loopIteration|gyro|setpoint|axis[PIDF]|rcCommand|motor\[|servo|headspeed|govTarget|rssi|debug)/;
+
+const POWER_MAIN_FIELDS =
+  /^(Vbat|vbatLatest|Ibat|amperage|Esc|current|energy|mAh)/i;
+
+const SLOW_FIELDS = /flag|failsafe|rx/i;
+
+// Tuning headers that describe the SETUP, not the pilot.
+const SETUP_HEADERS =
+  /^(gyro_|dterm_|d_min|rpm_|gov_|motor_poles|motor_pole|gear_ratio|rates|rc_rates|rc_expo|rollPID|pitchPID|yawPID|levelPID|filter|dyn_notch|acc_|pid_process_denom|looptime)/;
+
+// One degree of latitude ≈ 111,320 m; coordinates arrive as
+// degrees × 1e7, so one raw unit ≈ 1.11 cm.
+const METERS_PER_1E7_DEG_LAT = 0.0111320;
+
+function pickColumns(fieldNames, keepIndex) {
+  const indices = [];
+  const names = [];
+
+  fieldNames.forEach((name, i) => {
+    if (keepIndex(name)) {
+      indices.push(i);
+      names.push(name);
+    }
+  });
+
+  return { indices, names };
+}
+
+function projectFrames(frames, indices) {
+  return frames.map((frame) => indices.map((i) => frame[i]));
+}
+
+// GPS frames become a relative track: every coordinate is an
+// offset in meters from the FIRST fix of the flight. Absolute
+// coordinates never enter the payload.
+function buildRelativeGps(flight) {
+  const nameHeader = flight.headers?.get?.("Field G name");
+
+  if (!nameHeader || !flight.gpsFrames || flight.gpsFrames.length === 0) {
+    return null;
+  }
+
+  const gpsNames = nameHeader.split(",");
+  const latIndex = gpsNames.indexOf("GPS_coord[0]");
+  const lonIndex = gpsNames.indexOf("GPS_coord[1]");
+  const altIndex = gpsNames.indexOf("GPS_altitude");
+
+  const passThrough = ["GPS_speed", "GPS_ground_course", "GPS_numSat"]
+    .map((name) => ({ name, index: gpsNames.indexOf(name) }))
+    .filter((entry) => entry.index >= 0);
+
+  const first = flight.gpsFrames[0].values;
+  const lat0 = latIndex >= 0 ? first[latIndex] : 0;
+  const lon0 = lonIndex >= 0 ? first[lonIndex] : 0;
+  const alt0 = altIndex >= 0 ? first[altIndex] : 0;
+  const metersPerLon =
+    METERS_PER_1E7_DEG_LAT * Math.cos((lat0 * 1e-7 * Math.PI) / 180);
+
+  const fields = ["afterMainFrame"];
+  if (latIndex >= 0) fields.push("rel_north_m");
+  if (lonIndex >= 0) fields.push("rel_east_m");
+  if (altIndex >= 0) fields.push("rel_altitude");
+  passThrough.forEach((entry) => fields.push(entry.name));
+
+  const frames = flight.gpsFrames.map((gps) => {
+    const row = [gps.afterMainFrame];
+
+    if (latIndex >= 0) {
+      row.push(
+        Math.round((gps.values[latIndex] - lat0) * METERS_PER_1E7_DEG_LAT * 10) /
+          10
+      );
+    }
+    if (lonIndex >= 0) {
+      row.push(
+        Math.round((gps.values[lonIndex] - lon0) * metersPerLon * 10) / 10
+      );
+    }
+    if (altIndex >= 0) {
+      row.push(gps.values[altIndex] - alt0);
+    }
+    passThrough.forEach((entry) => row.push(gps.values[entry.index]));
+
+    return row;
+  });
+
+  return { fields, frames };
+}
+
+function buildSetupInfo(flight, includeSetup) {
+  const sysConfig = flight.sysConfig ?? {};
+  const info = {
+    firmwareType: sysConfig.firmwareType ?? null,
+    firmwareRevision: sysConfig.firmwareRevision ?? null
+  };
+
+  if (includeSetup) {
+    info.craftName = sysConfig.craftName ?? null;
+
+    const tuning = {};
+    if (flight.headers?.forEach) {
+      flight.headers.forEach((value, key) => {
+        if (SETUP_HEADERS.test(key)) {
+          tuning[key] = value;
+        }
+      });
+    }
+    info.tuning = tuning;
+  }
+
+  return info;
+}
+
+/**
+ * Build the anonymized contribution payload.
+ *
+ * @param {object} flight    decoded flight (bblDecoder shape)
+ * @param {string} fileType  e.g. "Blackbox BBL Log"
+ * @param {object} categories { power, gps, setup } booleans —
+ *                            core flight data is always included
+ * @param {string} appVersion
+ */
+export function buildContribution(flight, fileType, categories, appVersion) {
+  const keep = (name) =>
+    CORE_MAIN_FIELDS.test(name) ||
+    (categories.power === true && POWER_MAIN_FIELDS.test(name));
+
+  const main = pickColumns(flight.mainFieldNames ?? [], keep);
+  const slow = pickColumns(flight.slowFieldNames ?? [], (name) =>
+    SLOW_FIELDS.test(name)
+  );
+
+  const payload = {
+    schema: 1,
+    app: appVersion ?? null,
+    source: fileType,
+    durationSeconds: flight.durationSeconds ?? null,
+    categories: {
+      power: categories.power === true,
+      gps: categories.gps === true,
+      setup: categories.setup === true
+    },
+    setup: buildSetupInfo(flight, categories.setup === true),
+    fields: main.names,
+    frames: projectFrames(flight.mainFrames ?? [], main.indices),
+    slow: {
+      fields: slow.names,
+      frames: (flight.slowFrames ?? []).map((entry) => ({
+        afterMainFrame: entry.afterMainFrame,
+        values: slow.indices.map((i) => entry.values[i])
+      }))
+    }
+  };
+
+  if (categories.gps === true) {
+    const gps = buildRelativeGps(flight);
+    if (gps) {
+      payload.gps = gps;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Human summary for the consent UI: what WOULD be shared.
+ */
+export function describeContribution(payload) {
+  const parts = [
+    `${payload.fields.length} flight-data channels, ${payload.frames.length.toLocaleString()} frames`
+  ];
+
+  if (payload.gps) {
+    parts.push("GPS as relative track + speed (never your location)");
+  }
+  if (payload.categories.setup) {
+    parts.push("setup info (model + tuning values)");
+  }
+
+  return parts.join(" · ");
+}

--- a/src/contribute/uploader.js
+++ b/src/contribute/uploader.js
@@ -1,0 +1,39 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION UPLOADER
+//
+// Gzips the anonymized payload and POSTs it to the
+// community ingest endpoint. Fire-and-forget: failures
+// never interrupt the pilot, they just log to console.
+// ======================================================
+
+async function gzipJson(payload) {
+  const json = JSON.stringify(payload);
+
+  if (typeof CompressionStream === "undefined") {
+    return { body: json, encoding: null };
+  }
+
+  const stream = new Blob([json])
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"));
+  const body = await new Response(stream).blob();
+
+  return { body, encoding: "gzip" };
+}
+
+export async function uploadContribution(endpoint, payload) {
+  const { body, encoding } = await gzipJson(payload);
+
+  const headers = { "Content-Type": "application/json" };
+  if (encoding) {
+    headers["Content-Encoding"] = encoding;
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body
+  });
+
+  return { ok: response.ok, status: response.status };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,88 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- contribute (anonymized log sharing) ---------------- */
+
+.contribute-cats {
+  margin: 6px 0 4px 30px;
+  padding-left: 10px;
+  border-left: 2px solid var(--line-soft);
+}
+
+.contribute-status {
+  color: var(--ink-muted);
+  font-size: 13px;
+  margin: 10px 0 0 0;
+  min-height: 18px;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 12, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.overlay[hidden] {
+  display: none;
+}
+
+.overlay-dialog {
+  width: min(520px, 92vw);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px 28px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5);
+}
+
+.overlay-dialog h3 {
+  margin: 0 0 10px 0;
+  font-size: 20px;
+}
+
+.overlay-dialog p {
+  color: var(--ink-soft);
+  margin: 0 0 12px 0;
+}
+
+.overlay-privacy {
+  color: var(--ink-muted);
+  font-size: 14px;
+}
+
+.overlay-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.overlay-primary {
+  background: var(--accent-strong);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 11px 18px;
+}
+
+.overlay-primary:hover {
+  background: var(--accent);
+}
+
+.overlay-secondary {
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 11px 18px;
+}
+
+.overlay-footnote {
+  color: var(--ink-muted);
+  font-size: 12px;
+  margin: 12px 0 0 0;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -576,9 +576,98 @@
             </span>
           </label>
         </section>
+
+        <section class="card" id="contributeCard" hidden>
+          <h3>Share anonymized logs</h3>
+          <p>
+            Sharing an anonymized copy of the logs you open helps
+            improve the suggestions this tool gives everyone. Never
+            included: your name, dates, locations, or anything that
+            identifies you — and you choose what is shared:
+          </p>
+          <label class="toggle-row">
+            <input type="checkbox" id="contributeToggle" />
+            <span><strong>Share anonymized flight data</strong> —
+              gyro, control and motor channels that power the
+              analysis.</span>
+          </label>
+          <div class="contribute-cats">
+            <label class="toggle-row">
+              <input type="checkbox" id="contributePower" />
+              <span>Battery &amp; ESC data — voltage, current,
+                ESC telemetry.</span>
+            </label>
+            <label class="toggle-row">
+              <input type="checkbox" id="contributeGps" />
+              <span>GPS as relative track &amp; speed — the flight's
+                shape and speeds, <strong>never your
+                location</strong> (coordinates are reduced to
+                offsets from the first fix).</span>
+            </label>
+            <label class="toggle-row">
+              <input type="checkbox" id="contributeSetup" />
+              <span>Model &amp; tuning info — craft model and setup
+                values, so logs can be grouped by setup type.</span>
+            </label>
+          </div>
+          <p class="contribute-status" id="contributeStatus"></p>
+        </section>
+
+        <section class="card">
+          <h3>About this project</h3>
+          <p>
+            Blackbox Lab is a free, open-source community project —
+            built by hobbyists, for hobbyists, and provided free of
+            charge under the MIT license.
+          </p>
+          <p>
+            <strong>Use at your own risk.</strong> The tool and its
+            analyses are provided as-is, with no warranty of any
+            kind. Suggestions are informational — you remain the
+            pilot in command, and any change you make to your
+            helicopter is your own decision and responsibility. The
+            authors accept no liability for damage to equipment,
+            property, or persons.
+          </p>
+        </section>
       </section>
 
     </main>
+  </div>
+
+  <div class="overlay" id="contributeAsk" hidden>
+    <div class="overlay-dialog">
+      <h3>Help improve Blackbox Lab?</h3>
+      <p>
+        Share an anonymized copy of the logs you open. This directly
+        improves the suggestions the tool gives everyone — more real
+        flights means smarter advice.
+      </p>
+      <p class="overlay-privacy">
+        Never included: your name, dates, or your location.
+        You pick what is shared:
+      </p>
+      <label class="toggle-row">
+        <input type="checkbox" id="askPower" checked />
+        <span>Battery &amp; ESC data</span>
+      </label>
+      <label class="toggle-row">
+        <input type="checkbox" id="askGps" />
+        <span>GPS as relative track &amp; speed —
+          <strong>never your location</strong></span>
+      </label>
+      <label class="toggle-row">
+        <input type="checkbox" id="askSetup" checked />
+        <span>Model &amp; tuning info</span>
+      </label>
+      <div class="overlay-actions">
+        <button class="overlay-primary" id="askYes">Yes, share anonymized logs</button>
+        <button class="overlay-secondary" id="askNo">No thanks</button>
+      </div>
+      <p class="overlay-footnote">
+        You can change this anytime in Settings.
+      </p>
+    </div>
   </div>
 
   <script type="module" src="./renderer.js"></script>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,15 @@ import {
 } from "./ui/charts.js";
 import { buildReportHtml, downloadReport } from "./ui/reportBuilder.js";
 import { readLogFile } from "./analysis/logFileReader.js";
+import {
+  buildContribution,
+  describeContribution
+} from "./contribute/contributionBuilder.js";
+import { uploadContribution } from "./contribute/uploader.js";
+import {
+  CONTRIBUTE_ENDPOINT,
+  CONTRIBUTE_APP_VERSION
+} from "./contribute/config.js";
 import { buildLogAnalysis } from "./analysis/logAnalysisBuilder.js";
 import { findTelemetryHeaderIndex } from "./analysis/telemetryHeader.js";
 import { getColumnValues } from "./analysis/mathHelpers.js";
@@ -1089,6 +1098,11 @@ function analyzeFlight(flightIndex) {
   compareResultCard.hidden = true;
   compareChartCard.hidden = true;
 
+  // ---- community data sharing (opt-in, anonymized) ----
+  if (flight.mainFrames) {
+    maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+  }
+
   // Land the pilot on the answers, not the data.
   navigation.showScreen("home");
   document.querySelector(".workspace").scrollTop = 0;
@@ -1410,3 +1424,143 @@ clearHistoryButton.addEventListener("click", () => {
 
 refreshHistoryScreen();
 refreshCompareButtons();
+
+// ======================================================
+// Community data sharing — opt-in, anonymized.
+// Dormant unless CONTRIBUTE_ENDPOINT is configured.
+// ======================================================
+
+const CONTRIBUTE_PREF_KEY = "blackboxLabContribute";
+const CONTRIBUTE_CATS_KEY = "blackboxLabContributeCats";
+const contributedThisSession = new Set();
+
+const contributeCard = document.getElementById("contributeCard");
+const contributeToggle = document.getElementById("contributeToggle");
+const contributePower = document.getElementById("contributePower");
+const contributeGps = document.getElementById("contributeGps");
+const contributeSetup = document.getElementById("contributeSetup");
+const contributeStatus = document.getElementById("contributeStatus");
+const contributeAsk = document.getElementById("contributeAsk");
+
+function contributionEnabled() {
+  return (
+    Boolean(CONTRIBUTE_ENDPOINT) &&
+    localStorage.getItem(CONTRIBUTE_PREF_KEY) === "on"
+  );
+}
+
+function loadContributeCats() {
+  try {
+    const stored = JSON.parse(
+      localStorage.getItem(CONTRIBUTE_CATS_KEY) ?? ""
+    );
+    return {
+      power: stored.power === true,
+      gps: stored.gps === true,
+      setup: stored.setup === true
+    };
+  } catch {
+    return { power: true, gps: false, setup: true };
+  }
+}
+
+function saveContributeCats(cats) {
+  localStorage.setItem(CONTRIBUTE_CATS_KEY, JSON.stringify(cats));
+}
+
+function refreshContributeCard() {
+  if (!contributeCard) return;
+  contributeCard.hidden = !CONTRIBUTE_ENDPOINT;
+  if (!CONTRIBUTE_ENDPOINT) return;
+
+  const cats = loadContributeCats();
+  contributeToggle.checked =
+    localStorage.getItem(CONTRIBUTE_PREF_KEY) === "on";
+  contributePower.checked = cats.power;
+  contributeGps.checked = cats.gps;
+  contributeSetup.checked = cats.setup;
+
+  const disabled = !contributeToggle.checked;
+  [contributePower, contributeGps, contributeSetup].forEach((el) => {
+    el.disabled = disabled;
+  });
+}
+
+function maybeContributeFlight(flight, fileType, key) {
+  if (!contributionEnabled()) return;
+  if (contributedThisSession.has(key)) return;
+  contributedThisSession.add(key);
+
+  const payload = buildContribution(
+    flight,
+    fileType,
+    loadContributeCats(),
+    CONTRIBUTE_APP_VERSION
+  );
+
+  if (contributeStatus) {
+    contributeStatus.textContent = `Sharing: ${describeContribution(payload)} …`;
+  }
+
+  uploadContribution(CONTRIBUTE_ENDPOINT, payload)
+    .then((result) => {
+      if (contributeStatus) {
+        contributeStatus.textContent = result.ok
+          ? "Last log shared anonymously — thank you for helping the tool learn. ✓"
+          : `Sharing failed (server said ${result.status}) — the tool keeps working normally.`;
+      }
+    })
+    .catch(() => {
+      if (contributeStatus) {
+        contributeStatus.textContent =
+          "Sharing failed (no connection) — the tool keeps working normally.";
+      }
+    });
+}
+
+if (contributeToggle) {
+  contributeToggle.addEventListener("change", () => {
+    localStorage.setItem(
+      CONTRIBUTE_PREF_KEY,
+      contributeToggle.checked ? "on" : "off"
+    );
+    refreshContributeCard();
+  });
+
+  [contributePower, contributeGps, contributeSetup].forEach((el) => {
+    el.addEventListener("change", () => {
+      saveContributeCats({
+        power: contributePower.checked,
+        gps: contributeGps.checked,
+        setup: contributeSetup.checked
+      });
+    });
+  });
+}
+
+if (contributeAsk && CONTRIBUTE_ENDPOINT) {
+  const answered = localStorage.getItem(CONTRIBUTE_PREF_KEY) !== null;
+
+  if (!answered) {
+    contributeAsk.hidden = false;
+
+    document.getElementById("askYes").addEventListener("click", () => {
+      localStorage.setItem(CONTRIBUTE_PREF_KEY, "on");
+      saveContributeCats({
+        power: document.getElementById("askPower").checked,
+        gps: document.getElementById("askGps").checked,
+        setup: document.getElementById("askSetup").checked
+      });
+      contributeAsk.hidden = true;
+      refreshContributeCard();
+    });
+
+    document.getElementById("askNo").addEventListener("click", () => {
+      localStorage.setItem(CONTRIBUTE_PREF_KEY, "off");
+      contributeAsk.hidden = true;
+      refreshContributeCard();
+    });
+  }
+}
+
+refreshContributeCard();

--- a/test/contribution.test.mjs
+++ b/test/contribution.test.mjs
@@ -1,0 +1,156 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION (ANONYMIZATION) TESTS
+// ======================================================
+//
+// Run with:  npm test   (node --test)
+//
+// These tests are the privacy contract of the "share
+// anonymized logs" feature. If one of them fails, the
+// payload is leaking something it promised not to.
+//
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildContribution,
+  describeContribution
+} from "../src/contribute/contributionBuilder.js";
+
+// Synthetic decoded flight in the bblDecoder shape.
+// Home position: Vienna city center — must NEVER appear
+// in any payload.
+const LAT0 = 481_982_000; // 48.1982° in 1e-7 deg
+const LON0 = 163_738_000; // 16.3738°
+
+function makeFlight() {
+  return {
+    headers: new Map([
+      ["Field G name", "time,GPS_numSat,GPS_coord[0],GPS_coord[1],GPS_altitude,GPS_speed,GPS_ground_course"],
+      ["Log start datetime", "2026-07-23T18:41:02.123+00:00"],
+      ["gyro_lpf1_dyn_min_hz", "25"],
+      ["gov_headspeed", "1780"],
+      ["some_unknown_header", "whatever"]
+    ]),
+    sysConfig: {
+      firmwareType: "Rotorflight",
+      firmwareRevision: "4.6.0",
+      craftName: "Vince's Goosky RS7",
+      boardInformation: "SERIAL-XYZ-123",
+      logStartDatetime: "2026-07-23T18:41:02.123+00:00"
+    },
+    mainFieldNames: [
+      "time",
+      "gyroADC[0]",
+      "setpoint[0]",
+      "motor[0]",
+      "headspeed",
+      "Vbat",
+      "secretExperimentalField"
+    ],
+    mainFrames: [
+      [1000, 5, 0, 120, 0, 2333, 42],
+      [2000, 7, 1, 130, 500, 2331, 43]
+    ],
+    slowFieldNames: ["flightModeFlags", "failsafePhase", "privateThing"],
+    slowFrames: [{ afterMainFrame: 0, values: [3, 0, 99] }],
+    gpsFrames: [
+      { afterMainFrame: 0, values: [1000, 12, LAT0, LON0, 500, 0, 0] },
+      {
+        afterMainFrame: 1,
+        values: [2000, 12, LAT0 + 9000, LON0 + 4500, 520, 35, 90]
+      }
+    ],
+    durationSeconds: 133.5
+  };
+}
+
+const ALL_ON = { power: true, gps: true, setup: true };
+const ALL_OFF = { power: false, gps: false, setup: false };
+
+function payloadText(payload) {
+  return JSON.stringify(payload);
+}
+
+test("core payload never contains dates, board info, or unknown fields", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const text = payloadText(payload);
+
+  assert.ok(!text.includes("2026-07-23"), "log date leaked");
+  assert.ok(!text.includes("SERIAL-XYZ-123"), "board info leaked");
+  assert.ok(!text.includes("secretExperimentalField"), "unlisted main field leaked");
+  assert.ok(!text.includes("privateThing"), "unlisted slow field leaked");
+  assert.ok(!text.includes("some_unknown_header"), "unlisted header leaked");
+});
+
+test("absolute GPS coordinates never appear, even with GPS enabled", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const text = payloadText(payload);
+
+  assert.ok(!text.includes(String(LAT0)), "absolute latitude leaked");
+  assert.ok(!text.includes(String(LON0)), "absolute longitude leaked");
+  assert.ok(payload.gps, "gps section expected when enabled");
+
+  // First fix is the origin; second is ~100m north, ~50m east.
+  const [first, second] = payload.gps.frames;
+  const north = payload.gps.fields.indexOf("rel_north_m");
+  const east = payload.gps.fields.indexOf("rel_east_m");
+  assert.equal(first[north], 0);
+  assert.equal(first[east], 0);
+  assert.ok(Math.abs(second[north] - 100.2) < 1, `north offset ${second[north]}`);
+  assert.ok(Math.abs(second[east] - 33.4) < 5, `east offset ${second[east]}`);
+
+  // Altitude is relative to the first fix.
+  const alt = payload.gps.fields.indexOf("rel_altitude");
+  assert.equal(first[alt], 0);
+  assert.equal(second[alt], 20);
+});
+
+test("GPS off means no gps section at all", () => {
+  const payload = buildContribution(
+    makeFlight(),
+    "Blackbox BBL Log",
+    { power: true, gps: false, setup: true },
+    "0.3.0"
+  );
+  assert.equal(payload.gps, undefined);
+});
+
+test("craft name and tuning ship only with Setup enabled", () => {
+  const withSetup = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  assert.equal(withSetup.setup.craftName, "Vince's Goosky RS7");
+  assert.equal(withSetup.setup.tuning.gov_headspeed, "1780");
+
+  const withoutSetup = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_OFF, "0.3.0");
+  const text = payloadText(withoutSetup);
+  assert.ok(!text.includes("Goosky"), "craft name leaked with setup off");
+  assert.ok(!text.includes("gov_headspeed"), "tuning leaked with setup off");
+  // firmware info is always fine — it identifies software, not people
+  assert.equal(withoutSetup.setup.firmwareType, "Rotorflight");
+});
+
+test("power fields ship only with Power enabled", () => {
+  const withPower = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  assert.ok(withPower.fields.includes("Vbat"));
+
+  const withoutPower = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_OFF, "0.3.0");
+  assert.ok(!withoutPower.fields.includes("Vbat"));
+  // core channels survive regardless
+  assert.ok(withoutPower.fields.includes("gyroADC[0]"));
+  assert.ok(withoutPower.fields.includes("headspeed"));
+});
+
+test("frame projection keeps values aligned with kept fields", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const vbat = payload.fields.indexOf("Vbat");
+  assert.equal(payload.frames[0][vbat], 2333);
+  assert.equal(payload.frames[1][vbat], 2331);
+  assert.equal(payload.frames[0].length, payload.fields.length);
+});
+
+test("summary text mentions gps privacy when gps is shared", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const summary = describeContribution(payload);
+  assert.ok(summary.includes("never your location"));
+});


### PR DESCRIPTION
This is the data-collection feature we talked about, Daniel — built so it's safe to merge **today** and switch on **whenever you're ready**.

**What pilots experience**

- On first launch the app asks once: *Help improve Blackbox Lab?* — with checkboxes for what to include. Yes = every log they open is shared anonymized, automatically, in the background. No = nothing is ever sent. Changeable anytime in Settings.
- A new Settings card shows exactly what sharing means and lets them adjust it; a status line confirms each shared log.
- Also new: an About card in Settings saying the tool is a free community project, provided as-is, no warranty, use at your own risk.

**What the data can and can't contain**

Strict allowlist, enforced by 12 new tests (the test builds a fake flight containing a real city-center coordinate, a serial number, a log date and a pilot-named craft — and fails if any of them survive into the payload):

- Always: gyro/control/motor channels the analysis runs on
- Optional: battery+ESC, model+tuning info (so logs can be grouped by setup)
- Optional, off by default: GPS — reduced to a **relative** track: meters from the first fix, plus speed. Track shape and speeds survive; where it was flown doesn't.
- Never: names, dates, board serials, absolute coordinates, unknown fields

Full write-up: `Documentation/CONTRIBUTED-DATA.md` — written so you can link it publicly when someone asks what's collected.

**What it needs from you (later, no rush)**

The feature is **dormant** in this PR — the app behaves exactly as before until an ingest address exists. When you want to turn it on: `Documentation/ingest-endpoint-setup.md` walks you through creating the receiving end on Cloudflare's free tier, entirely in the browser (~10 minutes), and the logs land in a private bucket only you can read. Then one small edit to `src/contribute/config.js` (doable on GitHub in the browser) + a release, and it's live.

Suite is at 39 tests, UI smoke test green. Merge whenever you like — it changes nothing visible until the endpoint exists. 🚁