### PR TITLE
Stop accidental clicks on the sidebar's Open Blackbox Log button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,16 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- open-log guard ---------------- */
+
+.nav-lock {
+  float: right;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.nav-button.armed {
+  border-color: var(--accent-strong);
+  color: #ffffff;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,8 @@
 
       <button class="nav-button" data-target="home">Home</button>
       <button class="nav-button" data-target="guide">How to Use</button>
-      <button class="nav-button" id="openLogButton">Open Blackbox Log</button>
+      <button class="nav-button" id="openLogButton">Open Blackbox Log
+        <span class="nav-lock" id="openLogLock" hidden>🔒</span></button>
       <button class="nav-button" data-target="viewer">Log Viewer</button>
       <button class="nav-button" data-target="filter">Filter Lab</button>
       <button class="nav-button" data-target="pid">PID Lab</button>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -161,7 +161,48 @@ function openFilePicker() {
 }
 
 chooseFileButton.addEventListener("click", openFilePicker);
-openLogButton.addEventListener("click", openFilePicker);
+
+// The sidebar "Open Blackbox Log" sits between navigation tabs and
+// is easy to hit by accident once a log is loaded. After the first
+// load it locks: one click arms it (🔓 — "click again"), a second
+// click within a few seconds opens the picker. Before any log is
+// loaded it behaves like a normal button.
+const openLogLock = el("openLogLock");
+let openLogArmed = false;
+let openLogArmTimer = null;
+
+function disarmOpenLog() {
+  openLogArmed = false;
+  openLogButton.classList.remove("armed");
+  openLogButton.title = "";
+  if (openLogLock && !openLogLock.hidden) {
+    openLogLock.textContent = "🔒";
+  }
+  if (openLogArmTimer) {
+    clearTimeout(openLogArmTimer);
+    openLogArmTimer = null;
+  }
+}
+
+openLogButton.addEventListener("click", () => {
+  if (!loadedLog) {
+    openFilePicker();
+    return;
+  }
+
+  if (!openLogArmed) {
+    openLogArmed = true;
+    openLogLock.hidden = false;
+    openLogLock.textContent = "🔓";
+    openLogButton.classList.add("armed");
+    openLogButton.title = "Click again to open another log";
+    openLogArmTimer = setTimeout(disarmOpenLog, 3000);
+    return;
+  }
+
+  disarmOpenLog();
+  openFilePicker();
+});
 
 let loadedLog = null;
 
@@ -178,6 +219,12 @@ async function loadFromFile(file) {
   }
 
   loadedLog = logData;
+
+  // A log is in — lock the sidebar button against stray clicks.
+  if (openLogLock) {
+    openLogLock.hidden = false;
+  }
+  disarmOpenLog();
 
   flightSelect.innerHTML = "";
 


### PR DESCRIPTION
Tiny quality-of-life fix: once a log is loaded, the sidebar's **Open Blackbox Log** button was too easy to hit by accident while aiming for the tabs around it — and up popped the file dialog.

Now, after a log is loaded, the button shows a small 🔒. First click arms it (🔓 *click again to open another log*), a second click within 3 seconds opens the file dialog — a stray single click does nothing at all. Before any log is loaded it behaves exactly as before, and the big blue Open button on the Home screen is untouched.

Suite green, UI smoke test green. One click to merge. 🚁