### PR TITLE
A welcoming Home screen + update notice on startup

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,210 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- welcome (empty state) ----------------
+   Warm and inviting on purpose: this is the one screen a
+   brand-new pilot sees before their first log. The rest of
+   the app stays calm navy; here we allow a little sunrise. */
+
+:root {
+  --warm: #ffc46b;
+  --warm-deep: #ff9d5c;
+  --mint: #3ecf8e;
+  --mint-deep: #22b377;
+}
+
+body.log-loaded .welcome { display: none; }
+body:not(.log-loaded) .loaded-only { display: none; }
+
+.welcome {
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+  padding: 58px 40px 46px 40px;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background:
+    radial-gradient(ellipse 90% 60% at 50% -10%,
+      rgba(255, 196, 107, 0.16), transparent 60%),
+    linear-gradient(180deg, #12203a, var(--card));
+  margin-bottom: 18px;
+}
+
+.welcome.drop-armed {
+  border-color: var(--mint);
+  background:
+    radial-gradient(ellipse 90% 60% at 50% -10%,
+      rgba(62, 207, 142, 0.2), transparent 60%),
+    linear-gradient(180deg, #12203a, var(--card));
+}
+
+.welcome-glow {
+  position: absolute;
+  inset: -40% -20% auto -20%;
+  height: 70%;
+  background: radial-gradient(ellipse at 50% 0%,
+    rgba(255, 157, 92, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.welcome-copter {
+  font-size: 44px;
+  margin-bottom: 6px;
+  filter: drop-shadow(0 6px 16px rgba(255, 196, 107, 0.25));
+}
+
+.welcome-title {
+  font-size: 40px;
+  letter-spacing: -0.5px;
+  margin: 0 0 10px 0;
+  color: #ffffff;
+}
+
+.welcome-title span {
+  background: linear-gradient(90deg, var(--warm), var(--warm-deep));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.welcome-sub {
+  max-width: 560px;
+  margin: 0 auto 26px auto;
+  color: var(--ink-soft);
+  font-size: 16px;
+}
+
+.welcome-actions {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.welcome-primary {
+  background: linear-gradient(180deg, var(--mint), var(--mint-deep));
+  color: #06281a;
+  border: none;
+  border-radius: 999px;
+  padding: 15px 30px;
+  font-size: 16px;
+  font-weight: 700;
+  box-shadow: 0 8px 24px rgba(62, 207, 142, 0.28);
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+
+.welcome-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(62, 207, 142, 0.36);
+}
+
+.welcome-secondary {
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 15px 26px;
+  font-size: 15px;
+}
+
+.welcome-secondary:hover {
+  color: var(--ink);
+  background: var(--card-soft);
+}
+
+.welcome-drop-hint {
+  color: var(--ink-muted);
+  font-size: 13.5px;
+  margin: 16px 0 0 0;
+}
+
+.welcome-status {
+  color: var(--warm);
+  font-size: 14px;
+  min-height: 20px;
+  margin: 8px 0 0 0;
+}
+
+.welcome-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 12px;
+  max-width: 640px;
+  margin: 30px auto 0 auto;
+  text-align: left;
+}
+
+.welcome-step {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.welcome-step strong {
+  color: var(--ink);
+  font-size: 14.5px;
+}
+
+.welcome-step span:last-child {
+  color: var(--ink-muted);
+  font-size: 12.5px;
+}
+
+.welcome-step-num {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #06281a;
+  background: linear-gradient(180deg, var(--warm), var(--warm-deep));
+  margin-bottom: 6px;
+}
+
+/* ---------------- update banner ---------------- */
+
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(62, 207, 142, 0.09);
+  border: 1px solid rgba(62, 207, 142, 0.35);
+  border-radius: 12px;
+  padding: 11px 16px;
+  margin-bottom: 16px;
+  color: var(--ink);
+  font-size: 14px;
+}
+
+.update-banner[hidden] { display: none; }
+
+.update-banner-button {
+  margin-left: auto;
+  background: var(--mint);
+  color: #06281a;
+  border: none;
+  border-radius: 999px;
+  padding: 7px 16px;
+  font-weight: 650;
+  font-size: 13px;
+}
+
+.update-banner-button:hover { background: #55dba0; }
+
+.update-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--ink-muted);
+  font-size: 14px;
+  padding: 4px 6px;
+}
+
+.update-banner-dismiss:hover { color: var(--ink); }

--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,57 @@
 
       <!-- ============ HOME ============ -->
       <section data-screen="home">
-        <section class="hero">
+        <div class="update-banner" id="updateBanner" hidden>
+          <span id="updateBannerText"></span>
+          <button class="update-banner-button" id="updateBannerButton">
+            See what's new
+          </button>
+          <button class="update-banner-dismiss" id="updateBannerDismiss"
+            title="Not now">✕</button>
+        </div>
+
+        <!-- Welcome hero: the empty state before any log is loaded.
+             Hidden (body.log-loaded) the moment a flight is in. -->
+        <section class="welcome" id="welcomeHero">
+          <div class="welcome-glow" aria-hidden="true"></div>
+          <div class="welcome-copter" aria-hidden="true">🚁</div>
+          <h2 class="welcome-title">Your flight, <span>explained.</span></h2>
+          <p class="welcome-sub">
+            Drop in a log straight off your flight controller and get a
+            plain-language verdict — what's healthy, what to watch,
+            what to fix first. No jargon walls, no chart archaeology.
+          </p>
+          <div class="welcome-actions">
+            <button class="welcome-primary" id="welcomeOpenButton">
+              Open your Blackbox log
+            </button>
+            <button class="welcome-secondary" id="welcomeSampleButton">
+              Just looking? Try a sample flight
+            </button>
+          </div>
+          <p class="welcome-drop-hint">…or drag a <strong>.bbl</strong>
+            file anywhere onto this window</p>
+          <p class="welcome-status" id="welcomeStatus"></p>
+          <div class="welcome-steps">
+            <div class="welcome-step">
+              <span class="welcome-step-num">1</span>
+              <strong>Open your log</strong>
+              <span>.bbl works directly — no conversion</span>
+            </div>
+            <div class="welcome-step">
+              <span class="welcome-step-num">2</span>
+              <strong>Read your verdict</strong>
+              <span>plain words, evidence one click away</span>
+            </div>
+            <div class="welcome-step">
+              <span class="welcome-step-num">3</span>
+              <strong>Fix what matters</strong>
+              <span>one change per flight — then compare</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="hero loaded-only">
           <h2>Welcome to Blackbox Lab</h2>
           <p>Simple first. Deeper when you want it.</p>
         </section>
@@ -56,7 +106,7 @@
           <div id="qualityWarnings"></div>
         </section>
 
-        <section class="card">
+        <section class="card loaded-only">
           <h3>Start Here</h3>
           <p>
             Open a flight log from your helicopter — raw
@@ -88,7 +138,7 @@
           <div class="decode-info" id="decodeInfo"></div>
         </section>
 
-        <section class="card">
+        <section class="card loaded-only">
           <h3>Flight Summary</h3>
           <div class="summary-grid">
             <div>
@@ -108,7 +158,7 @@
           </div>
         </section>
 
-        <details class="card advanced-block">
+        <details class="card advanced-block loaded-only">
           <summary>Advanced: telemetry columns &amp; raw data</summary>
           <h4>Telemetry Columns</h4>
           <pre id="telemetryColumns">No telemetry loaded.</pre>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -29,6 +29,15 @@ const createWindow = () => {
 // Some APIs can only be used after this event occurs.
 // ---- sample flights bridge (read-only, whitelisted) ----
 const samplesDirectory = path.join(__dirname, '..', 'samples');
+
+// Open release pages in the pilot's real browser — only the
+// project's own GitHub URLs are allowed through.
+ipcMain.handle('open-external', (event, url) => {
+  if (typeof url === 'string' &&
+      url.startsWith('https://github.com/hillbilly1975/Blackbox_Lab')) {
+    shell.openExternal(url);
+  }
+});
 
 ipcMain.handle('list-sample-logs', () => {
   try {

--- a/src/preload.js
+++ b/src/preload.js
@@ -12,5 +12,6 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("blackboxLab", {
   readSampleLog: (name) => ipcRenderer.invoke("read-sample-log", name),
+  openExternal: (url) => ipcRenderer.invoke("open-external", url),
   listSampleLogs: () => ipcRenderer.invoke("list-sample-logs")
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,7 @@ import {
 } from "./ui/charts.js";
 import { buildReportHtml, downloadReport } from "./ui/reportBuilder.js";
 import { readLogFile } from "./analysis/logFileReader.js";
+import { APP_VERSION, checkForUpdate } from "./version.js";
 import { buildLogAnalysis } from "./analysis/logAnalysisBuilder.js";
 import { findTelemetryHeaderIndex } from "./analysis/telemetryHeader.js";
 import { getColumnValues } from "./analysis/mathHelpers.js";
@@ -195,6 +196,9 @@ async function loadFromFile(file) {
   await new Promise((resolve) => setTimeout(resolve, 30));
 
   analyzeFlight(0);
+
+  // Swap the welcome hero for the working Home layout.
+  document.body.classList.add("log-loaded");
 }
 
 logFileInput.addEventListener("change", async () => {
@@ -1410,3 +1414,78 @@ clearHistoryButton.addEventListener("click", () => {
 
 refreshHistoryScreen();
 refreshCompareButtons();
+
+
+// ======================================================
+// Welcome hero (empty state): extra open/sample buttons,
+// window-wide drag & drop, and a status mirror so loading
+// feedback is visible before the hero yields to the cards.
+// ======================================================
+
+const welcomeHero = el("welcomeHero");
+const welcomeStatus = el("welcomeStatus");
+
+el("welcomeOpenButton").addEventListener("click", openFilePicker);
+el("welcomeSampleButton").addEventListener("click", () => {
+  trySampleButton.click();
+});
+
+// Mirror every fileStatus message into the hero while it is
+// visible — loading feedback happens before .log-loaded flips.
+new MutationObserver(() => {
+  if (welcomeStatus) {
+    welcomeStatus.textContent = fileStatus.textContent;
+  }
+}).observe(fileStatus, { childList: true, characterData: true, subtree: true });
+
+// Drag & drop a log anywhere onto the window.
+window.addEventListener("dragover", (event) => {
+  event.preventDefault();
+  if (welcomeHero) welcomeHero.classList.add("drop-armed");
+});
+
+window.addEventListener("dragleave", (event) => {
+  if (event.relatedTarget === null && welcomeHero) {
+    welcomeHero.classList.remove("drop-armed");
+  }
+});
+
+window.addEventListener("drop", async (event) => {
+  event.preventDefault();
+  if (welcomeHero) welcomeHero.classList.remove("drop-armed");
+
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+
+  try {
+    await loadFromFile(file);
+  } catch (error) {
+    fileStatus.textContent =
+      "Something went wrong reading this log: " + error.message;
+  }
+});
+
+// ======================================================
+// Update check on startup (silent when offline/current).
+// ======================================================
+
+const updateBanner = el("updateBanner");
+const UPDATE_DISMISS_KEY = "blackboxLabUpdateDismissed";
+
+checkForUpdate(APP_VERSION).then((update) => {
+  if (!update || !updateBanner) return;
+  if (localStorage.getItem(UPDATE_DISMISS_KEY) === update.version) return;
+
+  el("updateBannerText").textContent =
+    `A new version of Blackbox Lab is out (${update.version} — you have v${APP_VERSION}).`;
+  updateBanner.hidden = false;
+
+  el("updateBannerButton").addEventListener("click", () => {
+    window.blackboxLab?.openExternal?.(update.url);
+  });
+
+  el("updateBannerDismiss").addEventListener("click", () => {
+    localStorage.setItem(UPDATE_DISMISS_KEY, update.version);
+    updateBanner.hidden = true;
+  });
+});

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,54 @@
+// ======================================================
+// BLACKBOX LAB — VERSION + UPDATE CHECK
+//
+// APP_VERSION mirrors package.json — bump both together
+// when releasing. checkForUpdate() asks GitHub's public
+// releases API once on startup; offline or rate-limited
+// just means silence, never an error for the pilot.
+// ======================================================
+
+export const APP_VERSION = "0.3.0";
+
+const RELEASES_API =
+  "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";
+
+function parseVersion(text) {
+  const match = String(text).trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isNewerVersion(candidate, current) {
+  const a = parseVersion(candidate);
+  const b = parseVersion(current);
+  if (!a || !b) return false;
+
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return false;
+}
+
+/**
+ * Resolves to { version, url } when a newer release exists,
+ * otherwise null. Never throws.
+ */
+export async function checkForUpdate(currentVersion = APP_VERSION) {
+  try {
+    const response = await fetch(RELEASES_API, {
+      headers: { Accept: "application/vnd.github+json" }
+    });
+    if (!response.ok) return null;
+
+    const release = await response.json();
+    if (release.draft || release.prerelease) return null;
+
+    if (isNewerVersion(release.tag_name, currentVersion)) {
+      return { version: release.tag_name, url: release.html_url };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/test/version.test.mjs
+++ b/test/version.test.mjs
@@ -1,0 +1,26 @@
+// ======================================================
+// BLACKBOX LAB — VERSION COMPARISON TESTS
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isNewerVersion } from "../src/version.js";
+
+test("newer versions are detected across all segments", () => {
+  assert.equal(isNewerVersion("v0.4.0", "0.3.0"), true);
+  assert.equal(isNewerVersion("0.3.1", "0.3.0"), true);
+  assert.equal(isNewerVersion("v1.0.0", "0.9.9"), true);
+});
+
+test("same or older versions never trigger", () => {
+  assert.equal(isNewerVersion("v0.3.0", "0.3.0"), false);
+  assert.equal(isNewerVersion("0.2.9", "0.3.0"), false);
+  assert.equal(isNewerVersion("v0.3.0-beta", "0.3.0"), false);
+});
+
+test("garbage tags never trigger", () => {
+  assert.equal(isNewerVersion("latest", "0.3.0"), false);
+  assert.equal(isNewerVersion("", "0.3.0"), false);
+  assert.equal(isNewerVersion(null, "0.3.0"), false);
+});

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -20,7 +20,7 @@ const { mkdirSync } = require("node:fs");
   await window.setViewportSize?.({ width: 1280, height: 900 }).catch(() => {});
 
   // ---- load the sample flight ----
-  await window.click("#trySampleButton");
+  await window.click("#welcomeSampleButton");
   await window.waitForTimeout(3500);
 
   const verdictCount = await window.evaluate(


### PR DESCRIPTION
Two front-door improvements, Daniel:

**1 — The empty Home screen earns its space now.** Before a log is loaded, instead of placeholder dashes there's a proper welcome: *Your flight, explained.* with a warm glow, one big green **Open your Blackbox log** button, the sample-flight path for the just-looking crowd, and a three-step strip showing the whole idea (open → verdict → fix). Pilots can also just **drag a .bbl anywhere onto the window** now. As soon as a flight loads, the hero steps aside and the familiar working layout takes over — nothing about the loaded view changed.

**2 — The app tells pilots when you ship a new version.** On startup it quietly checks your GitHub releases; if there's a newer one, a small green banner appears: *A new version of Blackbox Lab is out (v0.4.0 — you have v0.3.0)* with a button that opens the release page in their browser. Dismissable, remembers the dismissal per version, completely silent when offline or up to date. One thing to remember when releasing: bump the version in **both** `package.json` and `src/version.js` (they sit next to each other in the release checklist).

Suite at 35 tests, UI smoke green (screenshot of the new Home is in `smoke-shots/00-welcome-empty.png` after a smoke run). 🚁