### PR TITLE
v0.3.1 — everything from PRs 5–8 in one merge

### DIFF
--- a/Documentation/CONTRIBUTED-DATA.md
+++ b/Documentation/CONTRIBUTED-DATA.md
@@ -1,0 +1,43 @@
+# Contributed flight data — what is shared, exactly
+
+Blackbox Lab can (with the pilot's consent) share an anonymized copy
+of the logs it analyzes. This data helps improve the analysis and
+suggestions for everyone. This document is the complete, honest
+description of what leaves the pilot's machine.
+
+## The rules
+
+1. **Off until asked.** The app asks once, on first launch. "No
+   thanks" turns it off; nothing is ever sent. The choice can be
+   changed anytime in Settings.
+2. **Allowlist, not blocklist.** Only fields explicitly listed in
+   `src/contribute/contributionBuilder.js` are included. Anything
+   unknown is dropped by default — including future fields the
+   firmware might add.
+3. **Never included, in any configuration:**
+   - pilot names or accounts (the app doesn't know them)
+   - log dates and times
+   - board information / serial numbers
+   - absolute GPS coordinates — see below
+4. **The pilot picks categories:**
+   - *Core flight data* (always, when sharing is on): gyro,
+     setpoint, PID terms, motor/servo outputs, headspeed.
+   - *Battery & ESC* (optional): voltage, current, ESC telemetry.
+   - *GPS* (optional, off by default): reduced to a RELATIVE track —
+     every coordinate becomes an offset in meters from the first fix
+     of that flight, plus speed and heading. The flight's shape and
+     speeds survive; where it happened does not.
+   - *Model & tuning* (optional): craft model name and tuning values
+     (filters, governor, PIDs) so logs can be grouped by setup type.
+5. **Private storage.** Contributed logs go to the project's private
+   ingest endpoint and are used only to improve this tool. They are
+   not published or passed on.
+
+## Verifying this
+
+The privacy rules are enforced by tests
+(`test/contribution.test.mjs`) that build payloads from a synthetic
+flight containing deliberately sensitive values (a real city-center
+coordinate, a serial number, a log date, a pilot-named craft) and
+assert they never appear in the output. If a change breaks a rule,
+the test suite fails.

--- a/Documentation/ingest-endpoint-setup.md
+++ b/Documentation/ingest-endpoint-setup.md
@@ -1,0 +1,61 @@
+# Setting up the log ingest endpoint (all in the browser)
+
+The app's "share anonymized logs" feature needs one small piece of
+infrastructure: an address it can send contributed logs to. This
+guide sets one up on Cloudflare's free tier — no coding tools
+needed, everything happens on the Cloudflare website.
+
+The feature stays completely dormant in the app until the address
+is filled in (step 4), so there's no rush: the app works fine
+without it.
+
+## Step 1 — Create a Cloudflare account (if you don't have one)
+
+Go to dash.cloudflare.com, sign up (free plan is plenty).
+
+## Step 2 — Create the storage bucket
+
+1. In the left sidebar: **R2 Object Storage** → **Create bucket**.
+2. Name it `blackbox-logs`, leave everything else default, create.
+   (Buckets are PRIVATE by default — only you can read them.
+   Free tier includes 10 GB, which holds thousands of logs.)
+
+## Step 3 — Create the worker (the receiving address)
+
+1. Left sidebar: **Workers & Pages** → **Create** → **Worker**.
+2. Name it `blackbox-ingest`, deploy the hello-world it suggests.
+3. Click **Edit code**, delete everything, and paste the whole
+   contents of `Documentation/ingest-worker.js` from this repo.
+   Click **Deploy**.
+4. Back on the worker's page: **Settings** → **Bindings** →
+   **Add binding** → **R2 bucket**. Variable name: `LOGS`,
+   bucket: `blackbox-logs`. Save.
+5. The worker's address is shown at the top — something like
+   `https://blackbox-ingest.<your-name>.workers.dev`. Copy it.
+
+## Step 4 — Tell the app about it
+
+In the repo, edit `src/contribute/config.js` (this can be done on
+GitHub in the browser: open the file, click the pencil) and put the
+worker address between the quotes:
+
+    export const CONTRIBUTE_ENDPOINT =
+      "https://blackbox-ingest.<your-name>.workers.dev";
+
+Commit the change and publish a new release — from that version on,
+the app asks pilots on first launch and contributed logs start
+arriving in your bucket.
+
+## Reading the collected logs
+
+R2 → `blackbox-logs` → files are grouped by date, one JSON file
+(gzipped) per contributed flight. Download from the browser, or ask
+for tooling to analyze them in bulk once there's a pile.
+
+## Costs and abuse
+
+Free tier: 10 GB storage, 1M requests/day — hobby scale fits with
+huge room. The worker accepts at most 40 MB per upload and stores
+nothing about the sender (no IP, no account) — the payload is all
+there is. If someone ever abuses the address, rotating it is:
+rename the worker, update config.js, release.

--- a/Documentation/ingest-worker.js
+++ b/Documentation/ingest-worker.js
@@ -1,0 +1,38 @@
+// ======================================================
+// BLACKBOX LAB — LOG INGEST WORKER (Cloudflare)
+//
+// Paste-ready Cloudflare Worker: accepts contributed
+// logs from the app and stores them in a private R2
+// bucket. Setup guide: ingest-endpoint-setup.md
+// ======================================================
+
+const MAX_BODY_BYTES = 40 * 1024 * 1024; // 40 MB gzipped
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("Blackbox Lab ingest", { status: 200 });
+    }
+
+    const length = Number(request.headers.get("Content-Length") || 0);
+    if (length > MAX_BODY_BYTES) {
+      return new Response("too large", { status: 413 });
+    }
+
+    const body = await request.arrayBuffer();
+    if (body.byteLength === 0 || body.byteLength > MAX_BODY_BYTES) {
+      return new Response("bad body", { status: 400 });
+    }
+
+    // Object key: date prefix + random id. No IP, no
+    // user identifier — the payload is all there is.
+    const id = crypto.randomUUID();
+    const day = new Date().toISOString().slice(0, 10);
+    const gzipped =
+      request.headers.get("Content-Encoding") === "gzip" ? ".gz" : "";
+
+    await env.LOGS.put(`${day}/${id}.json${gzipped}`, body);
+
+    return new Response("thanks", { status: 200 });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blackbox-lab",
   "productName": "Blackbox Lab",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Rotorflight Blackbox analysis suite \u2014 simple first, deeper when you want it.",
   "main": "src/index.js",
   "private": true,

--- a/src/contribute/config.js
+++ b/src/contribute/config.js
@@ -11,4 +11,4 @@ export const CONTRIBUTE_ENDPOINT = "";
 
 // Reported inside the payload so contributed logs can be
 // grouped by app version. Update alongside package.json.
-export const CONTRIBUTE_APP_VERSION = "0.3.0";
+export const CONTRIBUTE_APP_VERSION = "0.3.1";

--- a/src/contribute/config.js
+++ b/src/contribute/config.js
@@ -1,0 +1,14 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION CONFIG
+//
+// The community ingest endpoint. Leave EMPTY to keep the
+// whole sharing feature dormant (no ask, no uploads) —
+// fill it in once the endpoint exists. Setup guide:
+// Documentation/ingest-endpoint-setup.md
+// ======================================================
+
+export const CONTRIBUTE_ENDPOINT = "";
+
+// Reported inside the payload so contributed logs can be
+// grouped by app version. Update alongside package.json.
+export const CONTRIBUTE_APP_VERSION = "0.3.0";

--- a/src/contribute/contributionBuilder.js
+++ b/src/contribute/contributionBuilder.js
@@ -1,0 +1,198 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION BUILDER
+//
+// Turns a decoded flight into the anonymized payload that
+// "Share anonymized logs" uploads. Strict ALLOWLIST design:
+// nothing leaves the machine unless a rule here names it.
+//
+// Privacy properties (tested in test/contribution.test.mjs):
+//   - no craft name unless the Setup category is enabled
+//   - no board information, no log date/time, ever
+//   - GPS is opt-in and RELATIVE only: track shape, speed
+//     and altitude survive; the pilot's location does not
+//   - unknown/unlisted fields are dropped, not forwarded
+// ======================================================
+
+const CORE_MAIN_FIELDS =
+  /^(time|loopIteration|gyro|setpoint|axis[PIDF]|rcCommand|motor\[|servo|headspeed|govTarget|rssi|debug)/;
+
+const POWER_MAIN_FIELDS =
+  /^(Vbat|vbatLatest|Ibat|amperage|Esc|current|energy|mAh)/i;
+
+const SLOW_FIELDS = /flag|failsafe|rx/i;
+
+// Tuning headers that describe the SETUP, not the pilot.
+const SETUP_HEADERS =
+  /^(gyro_|dterm_|d_min|rpm_|gov_|motor_poles|motor_pole|gear_ratio|rates|rc_rates|rc_expo|rollPID|pitchPID|yawPID|levelPID|filter|dyn_notch|acc_|pid_process_denom|looptime)/;
+
+// One degree of latitude ≈ 111,320 m; coordinates arrive as
+// degrees × 1e7, so one raw unit ≈ 1.11 cm.
+const METERS_PER_1E7_DEG_LAT = 0.0111320;
+
+function pickColumns(fieldNames, keepIndex) {
+  const indices = [];
+  const names = [];
+
+  fieldNames.forEach((name, i) => {
+    if (keepIndex(name)) {
+      indices.push(i);
+      names.push(name);
+    }
+  });
+
+  return { indices, names };
+}
+
+function projectFrames(frames, indices) {
+  return frames.map((frame) => indices.map((i) => frame[i]));
+}
+
+// GPS frames become a relative track: every coordinate is an
+// offset in meters from the FIRST fix of the flight. Absolute
+// coordinates never enter the payload.
+function buildRelativeGps(flight) {
+  const nameHeader = flight.headers?.get?.("Field G name");
+
+  if (!nameHeader || !flight.gpsFrames || flight.gpsFrames.length === 0) {
+    return null;
+  }
+
+  const gpsNames = nameHeader.split(",");
+  const latIndex = gpsNames.indexOf("GPS_coord[0]");
+  const lonIndex = gpsNames.indexOf("GPS_coord[1]");
+  const altIndex = gpsNames.indexOf("GPS_altitude");
+
+  const passThrough = ["GPS_speed", "GPS_ground_course", "GPS_numSat"]
+    .map((name) => ({ name, index: gpsNames.indexOf(name) }))
+    .filter((entry) => entry.index >= 0);
+
+  const first = flight.gpsFrames[0].values;
+  const lat0 = latIndex >= 0 ? first[latIndex] : 0;
+  const lon0 = lonIndex >= 0 ? first[lonIndex] : 0;
+  const alt0 = altIndex >= 0 ? first[altIndex] : 0;
+  const metersPerLon =
+    METERS_PER_1E7_DEG_LAT * Math.cos((lat0 * 1e-7 * Math.PI) / 180);
+
+  const fields = ["afterMainFrame"];
+  if (latIndex >= 0) fields.push("rel_north_m");
+  if (lonIndex >= 0) fields.push("rel_east_m");
+  if (altIndex >= 0) fields.push("rel_altitude");
+  passThrough.forEach((entry) => fields.push(entry.name));
+
+  const frames = flight.gpsFrames.map((gps) => {
+    const row = [gps.afterMainFrame];
+
+    if (latIndex >= 0) {
+      row.push(
+        Math.round((gps.values[latIndex] - lat0) * METERS_PER_1E7_DEG_LAT * 10) /
+          10
+      );
+    }
+    if (lonIndex >= 0) {
+      row.push(
+        Math.round((gps.values[lonIndex] - lon0) * metersPerLon * 10) / 10
+      );
+    }
+    if (altIndex >= 0) {
+      row.push(gps.values[altIndex] - alt0);
+    }
+    passThrough.forEach((entry) => row.push(gps.values[entry.index]));
+
+    return row;
+  });
+
+  return { fields, frames };
+}
+
+function buildSetupInfo(flight, includeSetup) {
+  const sysConfig = flight.sysConfig ?? {};
+  const info = {
+    firmwareType: sysConfig.firmwareType ?? null,
+    firmwareRevision: sysConfig.firmwareRevision ?? null
+  };
+
+  if (includeSetup) {
+    info.craftName = sysConfig.craftName ?? null;
+
+    const tuning = {};
+    if (flight.headers?.forEach) {
+      flight.headers.forEach((value, key) => {
+        if (SETUP_HEADERS.test(key)) {
+          tuning[key] = value;
+        }
+      });
+    }
+    info.tuning = tuning;
+  }
+
+  return info;
+}
+
+/**
+ * Build the anonymized contribution payload.
+ *
+ * @param {object} flight    decoded flight (bblDecoder shape)
+ * @param {string} fileType  e.g. "Blackbox BBL Log"
+ * @param {object} categories { power, gps, setup } booleans —
+ *                            core flight data is always included
+ * @param {string} appVersion
+ */
+export function buildContribution(flight, fileType, categories, appVersion) {
+  const keep = (name) =>
+    CORE_MAIN_FIELDS.test(name) ||
+    (categories.power === true && POWER_MAIN_FIELDS.test(name));
+
+  const main = pickColumns(flight.mainFieldNames ?? [], keep);
+  const slow = pickColumns(flight.slowFieldNames ?? [], (name) =>
+    SLOW_FIELDS.test(name)
+  );
+
+  const payload = {
+    schema: 1,
+    app: appVersion ?? null,
+    source: fileType,
+    durationSeconds: flight.durationSeconds ?? null,
+    categories: {
+      power: categories.power === true,
+      gps: categories.gps === true,
+      setup: categories.setup === true
+    },
+    setup: buildSetupInfo(flight, categories.setup === true),
+    fields: main.names,
+    frames: projectFrames(flight.mainFrames ?? [], main.indices),
+    slow: {
+      fields: slow.names,
+      frames: (flight.slowFrames ?? []).map((entry) => ({
+        afterMainFrame: entry.afterMainFrame,
+        values: slow.indices.map((i) => entry.values[i])
+      }))
+    }
+  };
+
+  if (categories.gps === true) {
+    const gps = buildRelativeGps(flight);
+    if (gps) {
+      payload.gps = gps;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Human summary for the consent UI: what WOULD be shared.
+ */
+export function describeContribution(payload) {
+  const parts = [
+    `${payload.fields.length} flight-data channels, ${payload.frames.length.toLocaleString()} frames`
+  ];
+
+  if (payload.gps) {
+    parts.push("GPS as relative track + speed (never your location)");
+  }
+  if (payload.categories.setup) {
+    parts.push("setup info (model + tuning values)");
+  }
+
+  return parts.join(" · ");
+}

--- a/src/contribute/uploader.js
+++ b/src/contribute/uploader.js
@@ -1,0 +1,39 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION UPLOADER
+//
+// Gzips the anonymized payload and POSTs it to the
+// community ingest endpoint. Fire-and-forget: failures
+// never interrupt the pilot, they just log to console.
+// ======================================================
+
+async function gzipJson(payload) {
+  const json = JSON.stringify(payload);
+
+  if (typeof CompressionStream === "undefined") {
+    return { body: json, encoding: null };
+  }
+
+  const stream = new Blob([json])
+    .stream()
+    .pipeThrough(new CompressionStream("gzip"));
+  const body = await new Response(stream).blob();
+
+  return { body, encoding: "gzip" };
+}
+
+export async function uploadContribution(endpoint, payload) {
+  const { body, encoding } = await gzipJson(payload);
+
+  const headers = { "Content-Type": "application/json" };
+  if (encoding) {
+    headers["Content-Encoding"] = encoding;
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body
+  });
+
+  return { ok: response.ok, status: response.status };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,88 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- contribute (anonymized log sharing) ---------------- */
+
+.contribute-cats {
+  margin: 6px 0 4px 30px;
+  padding-left: 10px;
+  border-left: 2px solid var(--line-soft);
+}
+
+.contribute-status {
+  color: var(--ink-muted);
+  font-size: 13px;
+  margin: 10px 0 0 0;
+  min-height: 18px;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 12, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.overlay[hidden] {
+  display: none;
+}
+
+.overlay-dialog {
+  width: min(520px, 92vw);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px 28px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5);
+}
+
+.overlay-dialog h3 {
+  margin: 0 0 10px 0;
+  font-size: 20px;
+}
+
+.overlay-dialog p {
+  color: var(--ink-soft);
+  margin: 0 0 12px 0;
+}
+
+.overlay-privacy {
+  color: var(--ink-muted);
+  font-size: 14px;
+}
+
+.overlay-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.overlay-primary {
+  background: var(--accent-strong);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 11px 18px;
+}
+
+.overlay-primary:hover {
+  background: var(--accent);
+}
+
+.overlay-secondary {
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 11px 18px;
+}
+
+.overlay-footnote {
+  color: var(--ink-muted);
+  font-size: 12px;
+  margin: 12px 0 0 0;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,46 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- chart footer (stats + zoom hint) ---------------- */
+
+.chart-footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+  min-height: 18px;
+}
+
+.chart-stats {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: var(--ink-muted);
+  font-size: 12px;
+}
+
+.chart-stat i {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  margin-right: 5px;
+  vertical-align: 0;
+}
+
+.chart-stat b {
+  color: var(--ink-soft);
+  font-weight: 650;
+}
+
+.chart-hint {
+  margin-left: auto;
+  color: var(--ink-muted);
+  font-size: 11.5px;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  opacity: 0.8;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,210 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- welcome (empty state) ----------------
+   Warm and inviting on purpose: this is the one screen a
+   brand-new pilot sees before their first log. The rest of
+   the app stays calm navy; here we allow a little sunrise. */
+
+:root {
+  --warm: #ffc46b;
+  --warm-deep: #ff9d5c;
+  --mint: #3ecf8e;
+  --mint-deep: #22b377;
+}
+
+body.log-loaded .welcome { display: none; }
+body:not(.log-loaded) .loaded-only { display: none; }
+
+.welcome {
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+  padding: 58px 40px 46px 40px;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background:
+    radial-gradient(ellipse 90% 60% at 50% -10%,
+      rgba(255, 196, 107, 0.16), transparent 60%),
+    linear-gradient(180deg, #12203a, var(--card));
+  margin-bottom: 18px;
+}
+
+.welcome.drop-armed {
+  border-color: var(--mint);
+  background:
+    radial-gradient(ellipse 90% 60% at 50% -10%,
+      rgba(62, 207, 142, 0.2), transparent 60%),
+    linear-gradient(180deg, #12203a, var(--card));
+}
+
+.welcome-glow {
+  position: absolute;
+  inset: -40% -20% auto -20%;
+  height: 70%;
+  background: radial-gradient(ellipse at 50% 0%,
+    rgba(255, 157, 92, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.welcome-copter {
+  font-size: 44px;
+  margin-bottom: 6px;
+  filter: drop-shadow(0 6px 16px rgba(255, 196, 107, 0.25));
+}
+
+.welcome-title {
+  font-size: 40px;
+  letter-spacing: -0.5px;
+  margin: 0 0 10px 0;
+  color: #ffffff;
+}
+
+.welcome-title span {
+  background: linear-gradient(90deg, var(--warm), var(--warm-deep));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.welcome-sub {
+  max-width: 560px;
+  margin: 0 auto 26px auto;
+  color: var(--ink-soft);
+  font-size: 16px;
+}
+
+.welcome-actions {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.welcome-primary {
+  background: linear-gradient(180deg, var(--mint), var(--mint-deep));
+  color: #06281a;
+  border: none;
+  border-radius: 999px;
+  padding: 15px 30px;
+  font-size: 16px;
+  font-weight: 700;
+  box-shadow: 0 8px 24px rgba(62, 207, 142, 0.28);
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+
+.welcome-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(62, 207, 142, 0.36);
+}
+
+.welcome-secondary {
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 15px 26px;
+  font-size: 15px;
+}
+
+.welcome-secondary:hover {
+  color: var(--ink);
+  background: var(--card-soft);
+}
+
+.welcome-drop-hint {
+  color: var(--ink-muted);
+  font-size: 13.5px;
+  margin: 16px 0 0 0;
+}
+
+.welcome-status {
+  color: var(--warm);
+  font-size: 14px;
+  min-height: 20px;
+  margin: 8px 0 0 0;
+}
+
+.welcome-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 12px;
+  max-width: 640px;
+  margin: 30px auto 0 auto;
+  text-align: left;
+}
+
+.welcome-step {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.welcome-step strong {
+  color: var(--ink);
+  font-size: 14.5px;
+}
+
+.welcome-step span:last-child {
+  color: var(--ink-muted);
+  font-size: 12.5px;
+}
+
+.welcome-step-num {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #06281a;
+  background: linear-gradient(180deg, var(--warm), var(--warm-deep));
+  margin-bottom: 6px;
+}
+
+/* ---------------- update banner ---------------- */
+
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(62, 207, 142, 0.09);
+  border: 1px solid rgba(62, 207, 142, 0.35);
+  border-radius: 12px;
+  padding: 11px 16px;
+  margin-bottom: 16px;
+  color: var(--ink);
+  font-size: 14px;
+}
+
+.update-banner[hidden] { display: none; }
+
+.update-banner-button {
+  margin-left: auto;
+  background: var(--mint);
+  color: #06281a;
+  border: none;
+  border-radius: 999px;
+  padding: 7px 16px;
+  font-weight: 650;
+  font-size: 13px;
+}
+
+.update-banner-button:hover { background: #55dba0; }
+
+.update-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--ink-muted);
+  font-size: 14px;
+  padding: 4px 6px;
+}
+
+.update-banner-dismiss:hover { color: var(--ink); }

--- a/src/index.css
+++ b/src/index.css
@@ -609,3 +609,16 @@ body.advanced-mode details.advanced-block {
 .advisor-recommendation.priority-first span {
   color: var(--attention);
 }
+
+/* ---------------- open-log guard ---------------- */
+
+.nav-lock {
+  float: right;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.nav-button.armed {
+  border-color: var(--accent-strong);
+  color: #ffffff;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,57 @@
 
       <!-- ============ HOME ============ -->
       <section data-screen="home">
-        <section class="hero">
+        <div class="update-banner" id="updateBanner" hidden>
+          <span id="updateBannerText"></span>
+          <button class="update-banner-button" id="updateBannerButton">
+            See what's new
+          </button>
+          <button class="update-banner-dismiss" id="updateBannerDismiss"
+            title="Not now">✕</button>
+        </div>
+
+        <!-- Welcome hero: the empty state before any log is loaded.
+             Hidden (body.log-loaded) the moment a flight is in. -->
+        <section class="welcome" id="welcomeHero">
+          <div class="welcome-glow" aria-hidden="true"></div>
+          <div class="welcome-copter" aria-hidden="true">🚁</div>
+          <h2 class="welcome-title">Your flight, <span>explained.</span></h2>
+          <p class="welcome-sub">
+            Drop in a log straight off your flight controller and get a
+            plain-language verdict — what's healthy, what to watch,
+            what to fix first. No jargon walls, no chart archaeology.
+          </p>
+          <div class="welcome-actions">
+            <button class="welcome-primary" id="welcomeOpenButton">
+              Open your Blackbox log
+            </button>
+            <button class="welcome-secondary" id="welcomeSampleButton">
+              Just looking? Try a sample flight
+            </button>
+          </div>
+          <p class="welcome-drop-hint">…or drag a <strong>.bbl</strong>
+            file anywhere onto this window</p>
+          <p class="welcome-status" id="welcomeStatus"></p>
+          <div class="welcome-steps">
+            <div class="welcome-step">
+              <span class="welcome-step-num">1</span>
+              <strong>Open your log</strong>
+              <span>.bbl works directly — no conversion</span>
+            </div>
+            <div class="welcome-step">
+              <span class="welcome-step-num">2</span>
+              <strong>Read your verdict</strong>
+              <span>plain words, evidence one click away</span>
+            </div>
+            <div class="welcome-step">
+              <span class="welcome-step-num">3</span>
+              <strong>Fix what matters</strong>
+              <span>one change per flight — then compare</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="hero loaded-only">
           <h2>Welcome to Blackbox Lab</h2>
           <p>Simple first. Deeper when you want it.</p>
         </section>
@@ -56,7 +106,7 @@
           <div id="qualityWarnings"></div>
         </section>
 
-        <section class="card">
+        <section class="card loaded-only">
           <h3>Start Here</h3>
           <p>
             Open a flight log from your helicopter — raw
@@ -88,7 +138,7 @@
           <div class="decode-info" id="decodeInfo"></div>
         </section>
 
-        <section class="card">
+        <section class="card loaded-only">
           <h3>Flight Summary</h3>
           <div class="summary-grid">
             <div>
@@ -108,7 +158,7 @@
           </div>
         </section>
 
-        <details class="card advanced-block">
+        <details class="card advanced-block loaded-only">
           <summary>Advanced: telemetry columns &amp; raw data</summary>
           <h4>Telemetry Columns</h4>
           <pre id="telemetryColumns">No telemetry loaded.</pre>

--- a/src/index.html
+++ b/src/index.html
@@ -576,9 +576,98 @@
             </span>
           </label>
         </section>
+
+        <section class="card" id="contributeCard" hidden>
+          <h3>Share anonymized logs</h3>
+          <p>
+            Sharing an anonymized copy of the logs you open helps
+            improve the suggestions this tool gives everyone. Never
+            included: your name, dates, locations, or anything that
+            identifies you — and you choose what is shared:
+          </p>
+          <label class="toggle-row">
+            <input type="checkbox" id="contributeToggle" />
+            <span><strong>Share anonymized flight data</strong> —
+              gyro, control and motor channels that power the
+              analysis.</span>
+          </label>
+          <div class="contribute-cats">
+            <label class="toggle-row">
+              <input type="checkbox" id="contributePower" />
+              <span>Battery &amp; ESC data — voltage, current,
+                ESC telemetry.</span>
+            </label>
+            <label class="toggle-row">
+              <input type="checkbox" id="contributeGps" />
+              <span>GPS as relative track &amp; speed — the flight's
+                shape and speeds, <strong>never your
+                location</strong> (coordinates are reduced to
+                offsets from the first fix).</span>
+            </label>
+            <label class="toggle-row">
+              <input type="checkbox" id="contributeSetup" />
+              <span>Model &amp; tuning info — craft model and setup
+                values, so logs can be grouped by setup type.</span>
+            </label>
+          </div>
+          <p class="contribute-status" id="contributeStatus"></p>
+        </section>
+
+        <section class="card">
+          <h3>About this project</h3>
+          <p>
+            Blackbox Lab is a free, open-source community project —
+            built by hobbyists, for hobbyists, and provided free of
+            charge under the MIT license.
+          </p>
+          <p>
+            <strong>Use at your own risk.</strong> The tool and its
+            analyses are provided as-is, with no warranty of any
+            kind. Suggestions are informational — you remain the
+            pilot in command, and any change you make to your
+            helicopter is your own decision and responsibility. The
+            authors accept no liability for damage to equipment,
+            property, or persons.
+          </p>
+        </section>
       </section>
 
     </main>
+  </div>
+
+  <div class="overlay" id="contributeAsk" hidden>
+    <div class="overlay-dialog">
+      <h3>Help improve Blackbox Lab?</h3>
+      <p>
+        Share an anonymized copy of the logs you open. This directly
+        improves the suggestions the tool gives everyone — more real
+        flights means smarter advice.
+      </p>
+      <p class="overlay-privacy">
+        Never included: your name, dates, or your location.
+        You pick what is shared:
+      </p>
+      <label class="toggle-row">
+        <input type="checkbox" id="askPower" checked />
+        <span>Battery &amp; ESC data</span>
+      </label>
+      <label class="toggle-row">
+        <input type="checkbox" id="askGps" />
+        <span>GPS as relative track &amp; speed —
+          <strong>never your location</strong></span>
+      </label>
+      <label class="toggle-row">
+        <input type="checkbox" id="askSetup" checked />
+        <span>Model &amp; tuning info</span>
+      </label>
+      <div class="overlay-actions">
+        <button class="overlay-primary" id="askYes">Yes, share anonymized logs</button>
+        <button class="overlay-secondary" id="askNo">No thanks</button>
+      </div>
+      <p class="overlay-footnote">
+        You can change this anytime in Settings.
+      </p>
+    </div>
   </div>
 
   <script type="module" src="./renderer.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,8 @@
 
       <button class="nav-button" data-target="home">Home</button>
       <button class="nav-button" data-target="guide">How to Use</button>
-      <button class="nav-button" id="openLogButton">Open Blackbox Log</button>
+      <button class="nav-button" id="openLogButton">Open Blackbox Log
+        <span class="nav-lock" id="openLogLock" hidden>🔒</span></button>
       <button class="nav-button" data-target="viewer">Log Viewer</button>
       <button class="nav-button" data-target="filter">Filter Lab</button>
       <button class="nav-button" data-target="pid">PID Lab</button>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -29,6 +29,15 @@ const createWindow = () => {
 // Some APIs can only be used after this event occurs.
 // ---- sample flights bridge (read-only, whitelisted) ----
 const samplesDirectory = path.join(__dirname, '..', 'samples');
+
+// Open release pages in the pilot's real browser — only the
+// project's own GitHub URLs are allowed through.
+ipcMain.handle('open-external', (event, url) => {
+  if (typeof url === 'string' &&
+      url.startsWith('https://github.com/hillbilly1975/Blackbox_Lab')) {
+    shell.openExternal(url);
+  }
+});
 
 ipcMain.handle('list-sample-logs', () => {
   try {

--- a/src/preload.js
+++ b/src/preload.js
@@ -12,5 +12,6 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("blackboxLab", {
   readSampleLog: (name) => ipcRenderer.invoke("read-sample-log", name),
+  openExternal: (url) => ipcRenderer.invoke("open-external", url),
   listSampleLogs: () => ipcRenderer.invoke("list-sample-logs")
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,15 @@ import {
 } from "./ui/charts.js";
 import { buildReportHtml, downloadReport } from "./ui/reportBuilder.js";
 import { readLogFile } from "./analysis/logFileReader.js";
+import {
+  buildContribution,
+  describeContribution
+} from "./contribute/contributionBuilder.js";
+import { uploadContribution } from "./contribute/uploader.js";
+import {
+  CONTRIBUTE_ENDPOINT,
+  CONTRIBUTE_APP_VERSION
+} from "./contribute/config.js";
 import { buildLogAnalysis } from "./analysis/logAnalysisBuilder.js";
 import { findTelemetryHeaderIndex } from "./analysis/telemetryHeader.js";
 import { getColumnValues } from "./analysis/mathHelpers.js";
@@ -1089,6 +1098,11 @@ function analyzeFlight(flightIndex) {
   compareResultCard.hidden = true;
   compareChartCard.hidden = true;
 
+  // ---- community data sharing (opt-in, anonymized) ----
+  if (flight.mainFrames) {
+    maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+  }
+
   // Land the pilot on the answers, not the data.
   navigation.showScreen("home");
   document.querySelector(".workspace").scrollTop = 0;
@@ -1410,3 +1424,143 @@ clearHistoryButton.addEventListener("click", () => {
 
 refreshHistoryScreen();
 refreshCompareButtons();
+
+// ======================================================
+// Community data sharing — opt-in, anonymized.
+// Dormant unless CONTRIBUTE_ENDPOINT is configured.
+// ======================================================
+
+const CONTRIBUTE_PREF_KEY = "blackboxLabContribute";
+const CONTRIBUTE_CATS_KEY = "blackboxLabContributeCats";
+const contributedThisSession = new Set();
+
+const contributeCard = document.getElementById("contributeCard");
+const contributeToggle = document.getElementById("contributeToggle");
+const contributePower = document.getElementById("contributePower");
+const contributeGps = document.getElementById("contributeGps");
+const contributeSetup = document.getElementById("contributeSetup");
+const contributeStatus = document.getElementById("contributeStatus");
+const contributeAsk = document.getElementById("contributeAsk");
+
+function contributionEnabled() {
+  return (
+    Boolean(CONTRIBUTE_ENDPOINT) &&
+    localStorage.getItem(CONTRIBUTE_PREF_KEY) === "on"
+  );
+}
+
+function loadContributeCats() {
+  try {
+    const stored = JSON.parse(
+      localStorage.getItem(CONTRIBUTE_CATS_KEY) ?? ""
+    );
+    return {
+      power: stored.power === true,
+      gps: stored.gps === true,
+      setup: stored.setup === true
+    };
+  } catch {
+    return { power: true, gps: false, setup: true };
+  }
+}
+
+function saveContributeCats(cats) {
+  localStorage.setItem(CONTRIBUTE_CATS_KEY, JSON.stringify(cats));
+}
+
+function refreshContributeCard() {
+  if (!contributeCard) return;
+  contributeCard.hidden = !CONTRIBUTE_ENDPOINT;
+  if (!CONTRIBUTE_ENDPOINT) return;
+
+  const cats = loadContributeCats();
+  contributeToggle.checked =
+    localStorage.getItem(CONTRIBUTE_PREF_KEY) === "on";
+  contributePower.checked = cats.power;
+  contributeGps.checked = cats.gps;
+  contributeSetup.checked = cats.setup;
+
+  const disabled = !contributeToggle.checked;
+  [contributePower, contributeGps, contributeSetup].forEach((el) => {
+    el.disabled = disabled;
+  });
+}
+
+function maybeContributeFlight(flight, fileType, key) {
+  if (!contributionEnabled()) return;
+  if (contributedThisSession.has(key)) return;
+  contributedThisSession.add(key);
+
+  const payload = buildContribution(
+    flight,
+    fileType,
+    loadContributeCats(),
+    CONTRIBUTE_APP_VERSION
+  );
+
+  if (contributeStatus) {
+    contributeStatus.textContent = `Sharing: ${describeContribution(payload)} …`;
+  }
+
+  uploadContribution(CONTRIBUTE_ENDPOINT, payload)
+    .then((result) => {
+      if (contributeStatus) {
+        contributeStatus.textContent = result.ok
+          ? "Last log shared anonymously — thank you for helping the tool learn. ✓"
+          : `Sharing failed (server said ${result.status}) — the tool keeps working normally.`;
+      }
+    })
+    .catch(() => {
+      if (contributeStatus) {
+        contributeStatus.textContent =
+          "Sharing failed (no connection) — the tool keeps working normally.";
+      }
+    });
+}
+
+if (contributeToggle) {
+  contributeToggle.addEventListener("change", () => {
+    localStorage.setItem(
+      CONTRIBUTE_PREF_KEY,
+      contributeToggle.checked ? "on" : "off"
+    );
+    refreshContributeCard();
+  });
+
+  [contributePower, contributeGps, contributeSetup].forEach((el) => {
+    el.addEventListener("change", () => {
+      saveContributeCats({
+        power: contributePower.checked,
+        gps: contributeGps.checked,
+        setup: contributeSetup.checked
+      });
+    });
+  });
+}
+
+if (contributeAsk && CONTRIBUTE_ENDPOINT) {
+  const answered = localStorage.getItem(CONTRIBUTE_PREF_KEY) !== null;
+
+  if (!answered) {
+    contributeAsk.hidden = false;
+
+    document.getElementById("askYes").addEventListener("click", () => {
+      localStorage.setItem(CONTRIBUTE_PREF_KEY, "on");
+      saveContributeCats({
+        power: document.getElementById("askPower").checked,
+        gps: document.getElementById("askGps").checked,
+        setup: document.getElementById("askSetup").checked
+      });
+      contributeAsk.hidden = true;
+      refreshContributeCard();
+    });
+
+    document.getElementById("askNo").addEventListener("click", () => {
+      localStorage.setItem(CONTRIBUTE_PREF_KEY, "off");
+      contributeAsk.hidden = true;
+      refreshContributeCard();
+    });
+  }
+}
+
+refreshContributeCard();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,6 +11,7 @@ import {
 } from "./ui/charts.js";
 import { buildReportHtml, downloadReport } from "./ui/reportBuilder.js";
 import { readLogFile } from "./analysis/logFileReader.js";
+import { APP_VERSION, checkForUpdate } from "./version.js";
 import { buildLogAnalysis } from "./analysis/logAnalysisBuilder.js";
 import { findTelemetryHeaderIndex } from "./analysis/telemetryHeader.js";
 import { getColumnValues } from "./analysis/mathHelpers.js";
@@ -195,6 +196,9 @@ async function loadFromFile(file) {
   await new Promise((resolve) => setTimeout(resolve, 30));
 
   analyzeFlight(0);
+
+  // Swap the welcome hero for the working Home layout.
+  document.body.classList.add("log-loaded");
 }
 
 logFileInput.addEventListener("change", async () => {
@@ -1410,3 +1414,78 @@ clearHistoryButton.addEventListener("click", () => {
 
 refreshHistoryScreen();
 refreshCompareButtons();
+
+
+// ======================================================
+// Welcome hero (empty state): extra open/sample buttons,
+// window-wide drag & drop, and a status mirror so loading
+// feedback is visible before the hero yields to the cards.
+// ======================================================
+
+const welcomeHero = el("welcomeHero");
+const welcomeStatus = el("welcomeStatus");
+
+el("welcomeOpenButton").addEventListener("click", openFilePicker);
+el("welcomeSampleButton").addEventListener("click", () => {
+  trySampleButton.click();
+});
+
+// Mirror every fileStatus message into the hero while it is
+// visible — loading feedback happens before .log-loaded flips.
+new MutationObserver(() => {
+  if (welcomeStatus) {
+    welcomeStatus.textContent = fileStatus.textContent;
+  }
+}).observe(fileStatus, { childList: true, characterData: true, subtree: true });
+
+// Drag & drop a log anywhere onto the window.
+window.addEventListener("dragover", (event) => {
+  event.preventDefault();
+  if (welcomeHero) welcomeHero.classList.add("drop-armed");
+});
+
+window.addEventListener("dragleave", (event) => {
+  if (event.relatedTarget === null && welcomeHero) {
+    welcomeHero.classList.remove("drop-armed");
+  }
+});
+
+window.addEventListener("drop", async (event) => {
+  event.preventDefault();
+  if (welcomeHero) welcomeHero.classList.remove("drop-armed");
+
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+
+  try {
+    await loadFromFile(file);
+  } catch (error) {
+    fileStatus.textContent =
+      "Something went wrong reading this log: " + error.message;
+  }
+});
+
+// ======================================================
+// Update check on startup (silent when offline/current).
+// ======================================================
+
+const updateBanner = el("updateBanner");
+const UPDATE_DISMISS_KEY = "blackboxLabUpdateDismissed";
+
+checkForUpdate(APP_VERSION).then((update) => {
+  if (!update || !updateBanner) return;
+  if (localStorage.getItem(UPDATE_DISMISS_KEY) === update.version) return;
+
+  el("updateBannerText").textContent =
+    `A new version of Blackbox Lab is out (${update.version} — you have v${APP_VERSION}).`;
+  updateBanner.hidden = false;
+
+  el("updateBannerButton").addEventListener("click", () => {
+    window.blackboxLab?.openExternal?.(update.url);
+  });
+
+  el("updateBannerDismiss").addEventListener("click", () => {
+    localStorage.setItem(UPDATE_DISMISS_KEY, update.version);
+    updateBanner.hidden = true;
+  });
+});

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -161,7 +161,48 @@ function openFilePicker() {
 }
 
 chooseFileButton.addEventListener("click", openFilePicker);
-openLogButton.addEventListener("click", openFilePicker);
+
+// The sidebar "Open Blackbox Log" sits between navigation tabs and
+// is easy to hit by accident once a log is loaded. After the first
+// load it locks: one click arms it (🔓 — "click again"), a second
+// click within a few seconds opens the picker. Before any log is
+// loaded it behaves like a normal button.
+const openLogLock = el("openLogLock");
+let openLogArmed = false;
+let openLogArmTimer = null;
+
+function disarmOpenLog() {
+  openLogArmed = false;
+  openLogButton.classList.remove("armed");
+  openLogButton.title = "";
+  if (openLogLock && !openLogLock.hidden) {
+    openLogLock.textContent = "🔒";
+  }
+  if (openLogArmTimer) {
+    clearTimeout(openLogArmTimer);
+    openLogArmTimer = null;
+  }
+}
+
+openLogButton.addEventListener("click", () => {
+  if (!loadedLog) {
+    openFilePicker();
+    return;
+  }
+
+  if (!openLogArmed) {
+    openLogArmed = true;
+    openLogLock.hidden = false;
+    openLogLock.textContent = "🔓";
+    openLogButton.classList.add("armed");
+    openLogButton.title = "Click again to open another log";
+    openLogArmTimer = setTimeout(disarmOpenLog, 3000);
+    return;
+  }
+
+  disarmOpenLog();
+  openFilePicker();
+});
 
 let loadedLog = null;
 
@@ -178,6 +219,12 @@ async function loadFromFile(file) {
   }
 
   loadedLog = logData;
+
+  // A log is in — lock the sidebar button against stray clicks.
+  if (openLogLock) {
+    openLogLock.hidden = false;
+  }
+  disarmOpenLog();
 
   flightSelect.innerHTML = "";
 

--- a/src/ui/charts.js
+++ b/src/ui/charts.js
@@ -65,6 +65,107 @@ function watchResize(element, chart) {
 // ------------------------------------------------------
 // Time series (x axis in seconds of flight time)
 // ------------------------------------------------------
+// Raw log columns are numbered, not named — translate the
+// number into the axis a pilot thinks in. RF axis order:
+// 0 = Roll, 1 = Pitch, 2 = Yaw, 3 = Collective.
+const AXIS_NAMES = ["Roll", "Pitch", "Yaw", "Collective"];
+
+export function friendlySeriesLabel(name) {
+  const match = String(name).match(/^([A-Za-z]+)\[(\d)\]$/);
+  if (!match) return name;
+
+  const axis = AXIS_NAMES[Number(match[2])];
+  if (!axis) return name;
+
+  const base = match[1];
+  if (/^gyroADC$/i.test(base)) return `${axis} gyro (filtered)`;
+  if (/^(gyroRAW|gyroUnfilt)$/i.test(base)) return `${axis} gyro (raw)`;
+  if (/^setpoint$/i.test(base)) return `${axis} target`;
+  if (/^axis([PIDF])$/i.test(base)) {
+    return `${axis} ${base.slice(-1).toUpperCase()}-term`;
+  }
+  if (/^rcCommand$/i.test(base)) return `${axis} stick`;
+  return name;
+}
+
+// Min/max of each visible series, recomputed on every zoom.
+function computeVisibleStats(u, seriesMeta) {
+  const xs = u.data[0];
+  const xMin = u.scales.x.min;
+  const xMax = u.scales.x.max;
+  const stats = [];
+
+  for (let s = 0; s < seriesMeta.length && s < 3; s += 1) {
+    const ys = u.data[s + 1];
+    let min = Infinity;
+    let max = -Infinity;
+    let minX = null;
+    let maxX = null;
+
+    for (let i = 0; i < xs.length; i += 1) {
+      if (xs[i] < xMin || xs[i] > xMax) continue;
+      const value = ys[i];
+      if (value == null) continue;
+      if (value < min) { min = value; minX = xs[i]; }
+      if (value > max) { max = value; maxX = xs[i]; }
+    }
+
+    if (minX !== null) {
+      stats.push({
+        label: seriesMeta[s].label,
+        color: seriesMeta[s].color,
+        min, minX, max, maxX
+      });
+    }
+  }
+
+  return stats;
+}
+
+const fmt = (value) =>
+  Math.abs(value) >= 100
+    ? String(Math.round(value))
+    : String(Math.round(value * 10) / 10);
+
+function buildChartFooter(element, chart, seriesMeta, { withStats }) {
+  const footer = document.createElement("div");
+  footer.className = "chart-footer";
+
+  const stats = document.createElement("div");
+  stats.className = "chart-stats";
+  footer.appendChild(stats);
+
+  const hint = document.createElement("div");
+  hint.className = "chart-hint";
+  hint.textContent = "drag to zoom · double-click to reset";
+  footer.appendChild(hint);
+
+  element.appendChild(footer);
+
+  if (!withStats) return;
+
+  const refresh = () => {
+    const visible = computeVisibleStats(chart, seriesMeta);
+    stats.innerHTML = visible
+      .map(
+        (entry) =>
+          `<span class="chart-stat"><i style="background:${entry.color}"></i>` +
+          `${entry.label}: ` +
+          `<b>▾ ${fmt(entry.min)}</b> @ ${entry.minX.toFixed(1)}s · ` +
+          `<b>▴ ${fmt(entry.max)}</b> @ ${entry.maxX.toFixed(1)}s</span>`
+      )
+      .join("");
+  };
+
+  // uPlot only creates hook arrays declared in its options —
+  // make sure the slot exists before subscribing.
+  chart.hooks.setScale = chart.hooks.setScale || [];
+  chart.hooks.setScale.push((u, key) => {
+    if (key === "x") refresh();
+  });
+  refresh();
+}
+
 export function renderTimeSeriesChart(element, options) {
   const {
     timeSeconds,
@@ -93,6 +194,32 @@ export function renderTimeSeriesChart(element, options) {
       },
       hooks: {
         draw: [
+          // Small dots on each visible series' min and max —
+          // they move with the zoom window.
+          (u) => {
+            const meta = u.__seriesMeta;
+            if (!meta) return;
+
+            const ctx = u.ctx;
+            ctx.save();
+            for (const entry of computeVisibleStats(u, meta)) {
+              for (const point of [
+                [entry.minX, entry.min],
+                [entry.maxX, entry.max]
+              ]) {
+                const x = u.valToPos(point[0], "x", true);
+                const y = u.valToPos(point[1], "y", true);
+                ctx.beginPath();
+                ctx.arc(x, y, 3.5, 0, Math.PI * 2);
+                ctx.fillStyle = entry.color;
+                ctx.fill();
+                ctx.strokeStyle = "rgba(7, 11, 18, 0.9)";
+                ctx.lineWidth = 1.5;
+                ctx.stroke();
+              }
+            }
+            ctx.restore();
+          },
           (u) => {
             if (!markers.length) {
               return;
@@ -147,7 +274,7 @@ export function renderTimeSeriesChart(element, options) {
             value == null ? "--" : value.toFixed(2)
         },
         ...series.map((entry, index) => ({
-          label: entry.label,
+          label: friendlySeriesLabel(entry.label),
           stroke: entry.color ?? CHART_COLORS[index % CHART_COLORS.length],
           width: 1.4,
           points: { show: false },
@@ -160,8 +287,15 @@ export function renderTimeSeriesChart(element, options) {
     element
   );
 
+  chart.__seriesMeta = series.map((entry, index) => ({
+    label: friendlySeriesLabel(entry.label),
+    color: entry.color ?? CHART_COLORS[index % CHART_COLORS.length]
+  }));
+
   element.__blackboxLabChart = chart;
   watchResize(element, chart);
+  buildChartFooter(element, chart, chart.__seriesMeta, { withStats: true });
+  chart.redraw();
 
   return chart;
 }
@@ -271,6 +405,7 @@ export function renderSpectrumChart(element, spectra, options = {}) {
 
   element.__blackboxLabChart = chart;
   watchResize(element, chart);
+  buildChartFooter(element, chart, [], { withStats: false });
 
   return chart;
 }

--- a/src/version.js
+++ b/src/version.js
@@ -7,7 +7,7 @@
 // just means silence, never an error for the pilot.
 // ======================================================
 
-export const APP_VERSION = "0.3.0";
+export const APP_VERSION = "0.3.1";
 
 const RELEASES_API =
   "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,54 @@
+// ======================================================
+// BLACKBOX LAB — VERSION + UPDATE CHECK
+//
+// APP_VERSION mirrors package.json — bump both together
+// when releasing. checkForUpdate() asks GitHub's public
+// releases API once on startup; offline or rate-limited
+// just means silence, never an error for the pilot.
+// ======================================================
+
+export const APP_VERSION = "0.3.0";
+
+const RELEASES_API =
+  "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";
+
+function parseVersion(text) {
+  const match = String(text).trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isNewerVersion(candidate, current) {
+  const a = parseVersion(candidate);
+  const b = parseVersion(current);
+  if (!a || !b) return false;
+
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return false;
+}
+
+/**
+ * Resolves to { version, url } when a newer release exists,
+ * otherwise null. Never throws.
+ */
+export async function checkForUpdate(currentVersion = APP_VERSION) {
+  try {
+    const response = await fetch(RELEASES_API, {
+      headers: { Accept: "application/vnd.github+json" }
+    });
+    if (!response.ok) return null;
+
+    const release = await response.json();
+    if (release.draft || release.prerelease) return null;
+
+    if (isNewerVersion(release.tag_name, currentVersion)) {
+      return { version: release.tag_name, url: release.html_url };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/test/contribution.test.mjs
+++ b/test/contribution.test.mjs
@@ -1,0 +1,156 @@
+// ======================================================
+// BLACKBOX LAB — CONTRIBUTION (ANONYMIZATION) TESTS
+// ======================================================
+//
+// Run with:  npm test   (node --test)
+//
+// These tests are the privacy contract of the "share
+// anonymized logs" feature. If one of them fails, the
+// payload is leaking something it promised not to.
+//
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildContribution,
+  describeContribution
+} from "../src/contribute/contributionBuilder.js";
+
+// Synthetic decoded flight in the bblDecoder shape.
+// Home position: Vienna city center — must NEVER appear
+// in any payload.
+const LAT0 = 481_982_000; // 48.1982° in 1e-7 deg
+const LON0 = 163_738_000; // 16.3738°
+
+function makeFlight() {
+  return {
+    headers: new Map([
+      ["Field G name", "time,GPS_numSat,GPS_coord[0],GPS_coord[1],GPS_altitude,GPS_speed,GPS_ground_course"],
+      ["Log start datetime", "2026-07-23T18:41:02.123+00:00"],
+      ["gyro_lpf1_dyn_min_hz", "25"],
+      ["gov_headspeed", "1780"],
+      ["some_unknown_header", "whatever"]
+    ]),
+    sysConfig: {
+      firmwareType: "Rotorflight",
+      firmwareRevision: "4.6.0",
+      craftName: "Vince's Goosky RS7",
+      boardInformation: "SERIAL-XYZ-123",
+      logStartDatetime: "2026-07-23T18:41:02.123+00:00"
+    },
+    mainFieldNames: [
+      "time",
+      "gyroADC[0]",
+      "setpoint[0]",
+      "motor[0]",
+      "headspeed",
+      "Vbat",
+      "secretExperimentalField"
+    ],
+    mainFrames: [
+      [1000, 5, 0, 120, 0, 2333, 42],
+      [2000, 7, 1, 130, 500, 2331, 43]
+    ],
+    slowFieldNames: ["flightModeFlags", "failsafePhase", "privateThing"],
+    slowFrames: [{ afterMainFrame: 0, values: [3, 0, 99] }],
+    gpsFrames: [
+      { afterMainFrame: 0, values: [1000, 12, LAT0, LON0, 500, 0, 0] },
+      {
+        afterMainFrame: 1,
+        values: [2000, 12, LAT0 + 9000, LON0 + 4500, 520, 35, 90]
+      }
+    ],
+    durationSeconds: 133.5
+  };
+}
+
+const ALL_ON = { power: true, gps: true, setup: true };
+const ALL_OFF = { power: false, gps: false, setup: false };
+
+function payloadText(payload) {
+  return JSON.stringify(payload);
+}
+
+test("core payload never contains dates, board info, or unknown fields", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const text = payloadText(payload);
+
+  assert.ok(!text.includes("2026-07-23"), "log date leaked");
+  assert.ok(!text.includes("SERIAL-XYZ-123"), "board info leaked");
+  assert.ok(!text.includes("secretExperimentalField"), "unlisted main field leaked");
+  assert.ok(!text.includes("privateThing"), "unlisted slow field leaked");
+  assert.ok(!text.includes("some_unknown_header"), "unlisted header leaked");
+});
+
+test("absolute GPS coordinates never appear, even with GPS enabled", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const text = payloadText(payload);
+
+  assert.ok(!text.includes(String(LAT0)), "absolute latitude leaked");
+  assert.ok(!text.includes(String(LON0)), "absolute longitude leaked");
+  assert.ok(payload.gps, "gps section expected when enabled");
+
+  // First fix is the origin; second is ~100m north, ~50m east.
+  const [first, second] = payload.gps.frames;
+  const north = payload.gps.fields.indexOf("rel_north_m");
+  const east = payload.gps.fields.indexOf("rel_east_m");
+  assert.equal(first[north], 0);
+  assert.equal(first[east], 0);
+  assert.ok(Math.abs(second[north] - 100.2) < 1, `north offset ${second[north]}`);
+  assert.ok(Math.abs(second[east] - 33.4) < 5, `east offset ${second[east]}`);
+
+  // Altitude is relative to the first fix.
+  const alt = payload.gps.fields.indexOf("rel_altitude");
+  assert.equal(first[alt], 0);
+  assert.equal(second[alt], 20);
+});
+
+test("GPS off means no gps section at all", () => {
+  const payload = buildContribution(
+    makeFlight(),
+    "Blackbox BBL Log",
+    { power: true, gps: false, setup: true },
+    "0.3.0"
+  );
+  assert.equal(payload.gps, undefined);
+});
+
+test("craft name and tuning ship only with Setup enabled", () => {
+  const withSetup = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  assert.equal(withSetup.setup.craftName, "Vince's Goosky RS7");
+  assert.equal(withSetup.setup.tuning.gov_headspeed, "1780");
+
+  const withoutSetup = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_OFF, "0.3.0");
+  const text = payloadText(withoutSetup);
+  assert.ok(!text.includes("Goosky"), "craft name leaked with setup off");
+  assert.ok(!text.includes("gov_headspeed"), "tuning leaked with setup off");
+  // firmware info is always fine — it identifies software, not people
+  assert.equal(withoutSetup.setup.firmwareType, "Rotorflight");
+});
+
+test("power fields ship only with Power enabled", () => {
+  const withPower = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  assert.ok(withPower.fields.includes("Vbat"));
+
+  const withoutPower = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_OFF, "0.3.0");
+  assert.ok(!withoutPower.fields.includes("Vbat"));
+  // core channels survive regardless
+  assert.ok(withoutPower.fields.includes("gyroADC[0]"));
+  assert.ok(withoutPower.fields.includes("headspeed"));
+});
+
+test("frame projection keeps values aligned with kept fields", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const vbat = payload.fields.indexOf("Vbat");
+  assert.equal(payload.frames[0][vbat], 2333);
+  assert.equal(payload.frames[1][vbat], 2331);
+  assert.equal(payload.frames[0].length, payload.fields.length);
+});
+
+test("summary text mentions gps privacy when gps is shared", () => {
+  const payload = buildContribution(makeFlight(), "Blackbox BBL Log", ALL_ON, "0.3.0");
+  const summary = describeContribution(payload);
+  assert.ok(summary.includes("never your location"));
+});

--- a/test/version.test.mjs
+++ b/test/version.test.mjs
@@ -1,0 +1,26 @@
+// ======================================================
+// BLACKBOX LAB — VERSION COMPARISON TESTS
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isNewerVersion } from "../src/version.js";
+
+test("newer versions are detected across all segments", () => {
+  assert.equal(isNewerVersion("v0.4.0", "0.3.0"), true);
+  assert.equal(isNewerVersion("0.3.1", "0.3.0"), true);
+  assert.equal(isNewerVersion("v1.0.0", "0.9.9"), true);
+});
+
+test("same or older versions never trigger", () => {
+  assert.equal(isNewerVersion("v0.3.0", "0.3.0"), false);
+  assert.equal(isNewerVersion("0.2.9", "0.3.0"), false);
+  assert.equal(isNewerVersion("v0.3.0-beta", "0.3.0"), false);
+});
+
+test("garbage tags never trigger", () => {
+  assert.equal(isNewerVersion("latest", "0.3.0"), false);
+  assert.equal(isNewerVersion("", "0.3.0"), false);
+  assert.equal(isNewerVersion(null, "0.3.0"), false);
+});

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -20,7 +20,7 @@ const { mkdirSync } = require("node:fs");
   await window.setViewportSize?.({ width: 1280, height: 900 }).catch(() => {});
 
   // ---- load the sample flight ----
-  await window.click("#trySampleButton");
+  await window.click("#welcomeSampleButton");
   await window.waitForTimeout(3500);
 
   const verdictCount = await window.evaluate(


### PR DESCRIPTION
Daniel — the four open PRs (#5 #6 #7 #8) touch some of the same files, so merging them one by one would make GitHub complain about conflicts after the first one. This PR is all four **already combined and re-tested** (42 tests, UI smoke green), plus the version bump to 0.3.1.

**So the whole plan is just:**

1. **Merge this PR** (the green button below). GitHub will automatically mark #5–#8 as merged too — no need to touch them.
2. **Publish the release:** repo front page → **Releases** → **Draft a new release** → tag `v0.3.1` (click *Create new tag on publish*) → title it → **Publish**. The robots build the Windows/Mac/Linux packages and attach them (~15 min, and this time Linux works too).
3. **Install and enjoy:** grab the new `Setup.exe` from the release. You'll see the new welcome screen, the chart min/max readouts and axis names, the zoom hint, and the sidebar lock.

What's inside (details in the individual PRs):
- #5 — opt-in anonymized log sharing (stays dormant until you set up the receiving end — `Documentation/ingest-endpoint-setup.md`, ~10 browser-minutes on Cloudflare's free tier, whenever you feel like it) + the About/disclaimer card
- #6 — sidebar Open-log button lock against accidental clicks
- #7 — the new welcome Home + drag-and-drop + **update notice on startup** (from this version on, the app tells pilots when you publish a new release)
- #8 — charts speak pilot: axis names, live min/max with dots, zoom hint

One recurring release-checklist note: bump the version in **package.json** and **src/version.js** together (this PR sets both to 0.3.1). 🚁