### PR TITLE
v0.3.4: feedforward doctrine fix + version banner + release repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
-## Unreleased
+## v0.3.4 — feedforward doctrine + release repair
+
+Builds directly on v0.3.3's scoring cleanup.
+
+### Fixed
+
+- Sustained feedforward output is no longer scored as PID-term
+  saturation. In Rotorflight, feedforward is supposed to do the
+  work during commanded motion, so sustained feedforward drive is
+  now reported as expected behavior (informational, no score
+  deduction). The v0.3.3 command-balance assessment remains the
+  feedforward health signal and the verdict text now points at it.
+- `src/version.js` now matches `package.json` again — v0.3.3
+  installs showed a permanent "update available" banner. A new
+  test keeps the two versions in lockstep from now on.
+- v0.3.3's release tag was missing the `v` prefix, so the
+  installer build never ran and its release page has no downloads.
+  v0.3.4 (tagged `v0.3.4`) is the first downloadable build that
+  carries all of the v0.3.3 fixes.
+
+### Added
+
+- Feedforward doctrine tests and the version lockstep test
+  (suite: 49 tests).
+
+## v0.3.3 — evidence and scoring cleanup
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blackbox-lab",
   "productName": "Blackbox Lab",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Rotorflight Blackbox analysis suite \u2014 simple first, deeper when you want it.",
   "main": "src/index.js",
   "private": true,

--- a/src/analysis/pidAnalysis.js
+++ b/src/analysis/pidAnalysis.js
@@ -57,6 +57,27 @@ function groupPidColumns(pidColumns) {
   return groups;
 }
 
+// Rotorflight doctrine: feedforward is supposed to carry the
+// work during commanded motion, so sustained near-peak
+// feedforward drive is expected behavior, never a fault. The
+// command-balance assessment is the feedforward health signal.
+export function applyFeedforwardDoctrine(
+  saturationAssessment
+) {
+  if (
+    saturationAssessment?.status !== "Review"
+  ) {
+    return saturationAssessment;
+  }
+
+  return {
+    ...saturationAssessment,
+    status: "Expected",
+    recommendation:
+      "Feedforward held near-maximum output for sustained periods. In Rotorflight, feedforward is supposed to do most of the work during commanded motion, so sustained feedforward drive is expected behavior and does not reduce the score. If this axis tracks poorly, review the command-balance result and gyro evidence instead of lowering feedforward."
+  };
+}
+
 export function analyzePids(
   analysisContext,
   lines = [],
@@ -1330,8 +1351,10 @@ const pidTermSaturationAssessment = {
     pidTermNearPeakActivity.feedforward.map(
       (termResult) => ({
         ...termResult,
-        ...classifyPidTermSaturation(
-          termResult
+        ...applyFeedforwardDoctrine(
+          classifyPidTermSaturation(
+            termResult
+          )
         )
       })
     )
@@ -1729,8 +1752,7 @@ const confidenceLevel =
  const saturationReviewTerms = [
   ...pidTermSaturationAssessment.p,
   ...pidTermSaturationAssessment.i,
-  ...pidTermSaturationAssessment.d,
-  ...pidTermSaturationAssessment.feedforward
+  ...pidTermSaturationAssessment.d
 ].filter(
   (termResult) =>
     termResult.status === "Review"
@@ -2752,7 +2774,7 @@ worstTrackingProfile
       ?.confidence ?? "Low"
   } confidence`,
 
-  `${axis} Feedforward saturation status: ${
+  `${axis} Feedforward sustained-drive status: ${
     pidTermSaturationAssessment.feedforward[
       axisIndex
     ]?.status ?? "Insufficient Data"
@@ -2774,8 +2796,7 @@ worstTrackingProfile
       ...[
   ...pidTermSaturationAssessment.p,
   ...pidTermSaturationAssessment.i,
-  ...pidTermSaturationAssessment.d,
-  ...pidTermSaturationAssessment.feedforward
+  ...pidTermSaturationAssessment.d
 ]
   .filter(
     (termResult) =>
@@ -2790,6 +2811,15 @@ worstTrackingProfile
       }% with a longest run of ${
         termResult.longestNearPeakRun ?? 0
       } samples. Compare this with command activity, tracking error, and the matching axis response before changing PID values.`
+  ),
+      ...pidTermSaturationAssessment.feedforward
+  .filter(
+    (termResult) =>
+      termResult.status === "Expected"
+  )
+  .map(
+    (termResult) =>
+      `${termResult.axis} ${termResult.columnName} held near-maximum output for sustained periods. In Rotorflight this is feedforward doing its intended work and it does not reduce the score. If ${termResult.axis} tracking is poor, review the command-balance result instead of lowering feedforward.`
   ),
       ...pidCommandBalanceAssessment
   .filter(

--- a/src/version.js
+++ b/src/version.js
@@ -7,7 +7,7 @@
 // just means silence, never an error for the pilot.
 // ======================================================
 
-export const APP_VERSION = "0.3.2";
+export const APP_VERSION = "0.3.4";
 
 const RELEASES_API =
   "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";

--- a/test/feedforwardDoctrine.test.mjs
+++ b/test/feedforwardDoctrine.test.mjs
@@ -1,0 +1,67 @@
+// ======================================================
+// BLACKBOX LAB — FEEDFORWARD DOCTRINE TESTS
+//
+// Rotorflight expects feedforward to carry the work during
+// commanded motion. Sustained near-peak feedforward must be
+// reported as expected behavior, never as a saturation fault
+// that lowers the tuning score.
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyFeedforwardDoctrine } from "../src/analysis/pidAnalysis.js";
+
+test("sustained feedforward drive is remapped from Review to Expected", () => {
+  const reviewAssessment = {
+    status: "Review",
+    confidence: "High",
+    recommendation:
+      "Repeated near-maximum PID-term activity was detected.",
+    sustainedRunDetected: true,
+    elevatedNearPeakActivity: true,
+    moderateNearPeakActivity: true
+  };
+
+  const result = applyFeedforwardDoctrine(reviewAssessment);
+
+  assert.equal(result.status, "Expected");
+  assert.equal(result.confidence, "High");
+  assert.match(
+    result.recommendation,
+    /command-balance/,
+    "the doctrine text must point at the command-balance result"
+  );
+  assert.match(
+    result.recommendation,
+    /does not reduce the score/
+  );
+});
+
+test("Clear feedforward assessments pass through untouched", () => {
+  const clearAssessment = {
+    status: "Clear",
+    confidence: "Medium",
+    recommendation:
+      "No repeated sustained PID-term saturation pattern was identified."
+  };
+
+  assert.deepEqual(
+    applyFeedforwardDoctrine(clearAssessment),
+    clearAssessment
+  );
+});
+
+test("Insufficient Data feedforward assessments pass through untouched", () => {
+  const insufficientAssessment = {
+    status: "Insufficient Data",
+    confidence: "Low",
+    recommendation:
+      "More valid PID-term samples are required before evaluating saturation."
+  };
+
+  assert.deepEqual(
+    applyFeedforwardDoctrine(insufficientAssessment),
+    insufficientAssessment
+  );
+});

--- a/test/version.test.mjs
+++ b/test/version.test.mjs
@@ -4,8 +4,30 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-import { isNewerVersion } from "../src/version.js";
+import {
+  APP_VERSION,
+  isNewerVersion
+} from "../src/version.js";
+
+test("APP_VERSION stays in lockstep with package.json", () => {
+  const packageJson = JSON.parse(
+    readFileSync(
+      fileURLToPath(
+        new URL("../package.json", import.meta.url)
+      ),
+      "utf8"
+    )
+  );
+
+  assert.equal(
+    APP_VERSION,
+    packageJson.version,
+    "src/version.js APP_VERSION and package.json version must be bumped together — a mismatch shows every user a permanent update banner"
+  );
+});
 
 test("newer versions are detected across all segments", () => {
   assert.equal(isNewerVersion("v0.4.0", "0.3.0"), true);


### PR DESCRIPTION
Great work on the 0.3.3 scoring cleanup — the stable-flight-phase detection and the honest "Insufficient Data" cards are exactly the right structure, and the new command-balance check is the correct foundation for judging feedforward. This PR builds on top of that with one scoring fix and repairs two small release hiccups so 0.3.4 goes out clean.

## What's in it

**1. Feedforward doctrine fix (completes the Ben feedback round)**
Feedforward was still included in the saturation deduction, so a motor doing exactly what Rotorflight wants (feedforward carrying the work during commanded motion) could lose up to 45 points. Now:
- Feedforward is exempt from the saturation deduction.
- Its near-peak stats stay visible, reported as an informational "Expected" status instead of "Review".
- The recommendation text points at YOUR command-balance result — that check is the real feedforward health signal, so this just wires the two halves together.
- P, I and D saturation scoring is unchanged.

**2. Version banner fix**
`src/version.js` still said 0.3.2 while `package.json` said 0.3.3 — that's why every 0.3.3 install shows a permanent "update available" banner. Both now read 0.3.4, and a new test makes the suite fail if they ever drift apart again.

**3. Why the 0.3.3 release page has no downloads**
The release was tagged `0.3.3` — without the `v` in front. The installer build only starts for tags that begin with `v`, so it never ran. Nothing to fix in the code; the release steps below take care of it.

Tests: 49 total, all green (1 skip is the usual missing-fixtures one). Changelog updated — your 0.3.3 notes are filed under their own heading.

## Release steps (all in the browser)

1. Press **Merge pull request** below, then **Confirm merge**.
2. Go to the repo's **Releases** page → **Draft a new release**.
3. Click **Choose a tag**, type exactly `v0.3.4` (with the v!), and pick **Create new tag: v0.3.4 on publish**.
4. Title it `Blackbox Lab v0.3.4`, paste the v0.3.4 section from CHANGELOG.md into the description, and press **Publish release**.
5. The **Actions** tab will show the Windows/Mac/Linux builds running (about 10–15 minutes). When they finish, the installers appear — either attached to your release or as a new draft release; if it's a draft, just open it and press **Publish**.
6. Optional check: install the Setup.exe — the app should say 0.3.4 and show **no** update banner.

The old 0.3.3 release can stay as it is or be deleted from the Releases page, whichever you prefer — v0.3.4 carries all of its fixes.
