### PR TITLE
Per-axis tuning preset charts: Roll/Pitch/Yaw × Tracking / FF check / Term balance

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -274,7 +274,7 @@
         </section>
 
         <section class="card">
-          <h3>Setpoint vs Gyro</h3>
+          <h3>Roll Tuning</h3>
           <p class="chart-hint">
             What you asked for versus what you got — the heart of tuning.
             The closer the lines hug, the better the tune.
@@ -282,6 +282,70 @@
           <div class="chart-container" id="chartTracking">
             <p class="chart-empty">Open a log to see this chart.</p>
           </div>
+          <details class="advanced-block" open>
+            <summary>Advanced: feedforward &amp; term balance</summary>
+            <p class="chart-hint">
+              Feedforward check — if the gyro follows the target while
+              the I-term stays near zero, feedforward is carrying the
+              maneuver, exactly as Rotorflight intends.
+            </p>
+            <div class="chart-container" id="chartFfRoll">
+              <p class="chart-empty">Open a log to see this chart.</p>
+            </div>
+            <p class="chart-hint">
+              Term balance — which controller term is doing the work.
+              Watch for I wind-up, D-term buzz, and whether term
+              activity lines up with your commands.
+            </p>
+            <div class="chart-container" id="chartTermsRoll">
+              <p class="chart-empty">Open a log to see this chart.</p>
+            </div>
+          </details>
+        </section>
+
+        <section class="card">
+          <h3>Pitch Tuning</h3>
+          <p class="chart-hint">
+            Target versus response on the pitch axis.
+          </p>
+          <div class="chart-container" id="chartTrackingPitch">
+            <p class="chart-empty">Open a log to see this chart.</p>
+          </div>
+          <details class="advanced-block" open>
+            <summary>Advanced: feedforward &amp; term balance</summary>
+            <p class="chart-hint">
+              Feedforward check and term balance, pitch axis.
+            </p>
+            <div class="chart-container" id="chartFfPitch">
+              <p class="chart-empty">Open a log to see this chart.</p>
+            </div>
+            <div class="chart-container" id="chartTermsPitch">
+              <p class="chart-empty">Open a log to see this chart.</p>
+            </div>
+          </details>
+        </section>
+
+        <section class="card">
+          <h3>Yaw Tuning</h3>
+          <p class="chart-hint">
+            Target versus response on the tail — the axis that shows
+            mechanical and tune problems first.
+          </p>
+          <div class="chart-container" id="chartTrackingYaw">
+            <p class="chart-empty">Open a log to see this chart.</p>
+          </div>
+          <details class="advanced-block" open>
+            <summary>Advanced: feedforward &amp; term balance</summary>
+            <p class="chart-hint">
+              Feedforward check and term balance, yaw axis.
+            </p>
+            <div class="chart-container" id="chartFfYaw">
+              <p class="chart-empty">Open a log to see this chart.</p>
+            </div>
+            <div class="chart-container" id="chartTermsYaw">
+              <p class="chart-empty">Open a log to see this chart.</p>
+            </div>
+          </details>
         </section>
 
         <section class="card">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -98,6 +98,14 @@ const pidAnalysisRecommendations = el("pidAnalysisRecommendations");
 const chartGyro = el("chartGyro");
 const chartThrottle = el("chartThrottle");
 const chartTracking = el("chartTracking");
+const chartTrackingPitch = el("chartTrackingPitch");
+const chartTrackingYaw = el("chartTrackingYaw");
+const chartFfRoll = el("chartFfRoll");
+const chartFfPitch = el("chartFfPitch");
+const chartFfYaw = el("chartFfYaw");
+const chartTermsRoll = el("chartTermsRoll");
+const chartTermsPitch = el("chartTermsPitch");
+const chartTermsYaw = el("chartTermsYaw");
 const chartHeadspeed = el("chartHeadspeed");
 const chartPower = el("chartPower");
 const chartSpectrum = el("chartSpectrum");
@@ -1051,10 +1059,80 @@ function renderScaledChart(element, dataset, entries, yLabel) {
   });
 }
 
+// ---- Ben's preset grid: per axis, three opinionated charts ----
+// Tracking (setpoint + gyro), FF check (+ I-term: I ≈ 0 during a
+// followed command = feedforward carrying the work), term balance
+// (setpoint anchors P/I/D activity to pilot input). Colors stay
+// per-role across all nine charts so the eye can jump between them.
+const PRESET_COLORS = {
+  setpoint: CHART_COLORS[0], // blue — the target
+  gyro: CHART_COLORS[1], // orange — the response
+  i: CHART_COLORS[2], // green — I-term
+  p: CHART_COLORS[3], // amber — P-term
+  d: CHART_COLORS[4] // magenta — D-term
+};
+
+function renderPresetChart(element, dataset, entries, yLabel) {
+  const series = [];
+
+  for (const entry of entries) {
+    const column = dataset.findColumnsIn(entry.patterns)[0];
+
+    if (column) {
+      series.push({
+        label: column,
+        values: decimate(dataset.columnValues(column)),
+        color: entry.color
+      });
+    }
+  }
+
+  // One lonely line can't show a relationship — every preset
+  // compares traces, so ask for at least two.
+  if (series.length < 2) {
+    element.innerHTML =
+      '<p class="chart-empty">This log has no data for this chart.</p>';
+    return;
+  }
+
+  renderTimeSeriesChart(element, {
+    timeSeconds: decimate(dataset.timeSeconds),
+    series,
+    yLabel,
+    height: 220
+  });
+}
+
+function renderTuningPresets(dataset) {
+  const axes = [
+    { index: 0, tracking: chartTracking, ff: chartFfRoll, terms: chartTermsRoll },
+    { index: 1, tracking: chartTrackingPitch, ff: chartFfPitch, terms: chartTermsPitch },
+    { index: 2, tracking: chartTrackingYaw, ff: chartFfYaw, terms: chartTermsYaw }
+  ];
+
+  for (const axis of axes) {
+    const column = (base) =>
+      new RegExp(`^${base}\\[${axis.index}\\]$`, "i");
+
+    const setpoint = { patterns: [column("setpoint")], color: PRESET_COLORS.setpoint };
+    const gyro = { patterns: [column("gyroADC")], color: PRESET_COLORS.gyro };
+    const iTerm = { patterns: [column("axisI")], color: PRESET_COLORS.i };
+    const pTerm = { patterns: [column("axisP")], color: PRESET_COLORS.p };
+    const dTerm = { patterns: [column("axisD")], color: PRESET_COLORS.d };
+
+    renderPresetChart(axis.tracking, dataset, [setpoint, gyro], "deg/s");
+    renderPresetChart(axis.ff, dataset, [setpoint, gyro, iTerm], "deg/s · term output");
+    renderPresetChart(axis.terms, dataset, [setpoint, pTerm, iTerm, dTerm], "deg/s · term output");
+  }
+}
+
 function renderAllCharts(dataset) {
   if (!dataset) {
     for (const element of [
-      chartGyro, chartTracking, chartHeadspeed, chartThrottle, chartPower,
+      chartGyro, chartTracking, chartTrackingPitch, chartTrackingYaw,
+      chartFfRoll, chartFfPitch, chartFfYaw,
+      chartTermsRoll, chartTermsPitch, chartTermsYaw,
+      chartHeadspeed, chartThrottle, chartPower,
       chartSpectrum, chartGovernor, chartEsc, chartBattery
     ]) {
       element.innerHTML =
@@ -1068,12 +1146,7 @@ function renderAllCharts(dataset) {
     yLabel: "deg/s"
   });
 
-  renderSeriesChart(
-    chartTracking,
-    dataset,
-    [/^setpoint\[0\]/i, /^gyroADC\[0\]/i],
-    { yLabel: "roll axis" }
-  );
+  renderTuningPresets(dataset);
 
   renderSeriesChart(
     chartHeadspeed,
@@ -1407,7 +1480,9 @@ buildReportButton.addEventListener("click", () => {
     chartElements: [
       { title: "Noise Spectrum", element: chartSpectrum },
       { title: "Gyro", element: chartGyro },
-      { title: "Setpoint vs Gyro", element: chartTracking },
+      { title: "Roll: Target vs Gyro", element: chartTracking },
+      { title: "Pitch: Target vs Gyro", element: chartTrackingPitch },
+      { title: "Yaw: Target vs Gyro", element: chartTrackingYaw },
       { title: "Headspeed & Governor", element: chartGovernor },
       { title: "Throttle", element: chartThrottle },
       { title: "Battery & Current", element: chartPower }

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -50,6 +50,31 @@ const { mkdirSync } = require("node:fs");
   }
   console.log("chart scale ok:", JSON.stringify(chartState));
 
+  // Same guard for the per-axis tuning preset grid — all nine
+  // charts must exist with scaled data (they render even while
+  // their advanced blocks are hidden in beginner mode).
+  const presetState = await window.evaluate(() => {
+    const ids = [
+      "chartTracking", "chartTrackingPitch", "chartTrackingYaw",
+      "chartFfRoll", "chartFfPitch", "chartFfYaw",
+      "chartTermsRoll", "chartTermsPitch", "chartTermsYaw"
+    ];
+    return ids.map((id) => {
+      const el = document.getElementById(id);
+      const u = el && el.__blackboxLabChart;
+      return {
+        id,
+        ok: Boolean(u && u.scales.x.min != null && u.scales.x.max > u.scales.x.min)
+      };
+    });
+  });
+  const badPresets = presetState.filter((entry) => !entry.ok);
+  if (badPresets.length) {
+    throw new Error("preset charts without scaled data: " +
+      badPresets.map((entry) => entry.id).join(", "));
+  }
+  console.log("preset grid ok: 9/9 charts scaled");
+
   await window.click(".verdict-jump");
   await window.waitForTimeout(600);
   await window.screenshot({ path: "smoke-shots/02-filter-zoomed.png" });


### PR DESCRIPTION
This one comes straight from Ben Britton's feedback: he loved that everything is "all there, all laid out" compared to building graphs by hand in Blackbox Explorer — and asked for exactly one thing the viewer didn't have yet: the tuning charts for **all three axes**, not just roll, laid out as ready-made presets.

## What's new

The single "Setpoint vs Gyro" chart (roll only) becomes three cards — **Roll Tuning, Pitch Tuning, Yaw Tuning** — and each card holds three preset charts, no configuration needed:

| Preset | Traces | What it answers |
|---|---|---|
| Tracking | target + gyro | Did the heli do what the pilot asked? Overshoot, bounce-back. |
| Feedforward check | target + gyro + I-term | If the gyro follows the target while I stays near zero, feedforward is carrying the maneuver — exactly what Rotorflight wants. |
| Term balance | target + P + I + D | Which term is doing the work; I wind-up; D-term buzz — anchored to pilot input. |

Details that keep it friendly:

- **Beginner mode stays calm**: each card shows only the Tracking chart. The feedforward and term-balance charts sit in the card's "Advanced" block — hidden for beginners, already expanded when Advanced mode is on.
- **Same color always means the same thing** across all nine charts: blue = target, orange = gyro, green = I, amber = P, magenta = D. Once your eye learns it on roll, it reads pitch and yaw for free.
- Every chart keeps the usual goodies: plain-language labels, live min/max readouts that follow the zoom, drag-to-zoom hint.
- Logs that don't record some term (many logs have no D on every axis) just show the traces they have; a chart needs at least two traces to mean anything, otherwise it shows the normal "no data" note.
- The HTML report now includes the tracking chart for **all three axes** (it only had roll before).
- The UI smoke test now asserts all nine preset charts actually compute scaled data — blank-chart regressions can't slip through.

Try it with the sample flight: the Yaw card is a nice demo — during the pirouette you can watch the green I-term climb up and carry the whole command, which is exactly the "I is doing the work" pattern the command-balance check in the analysis looks for. The charts and the verdict now tell the same story.

Tests: full suite green, smoke test green (screenshots checked). No changelog edit in this PR on purpose — #11 already touches CHANGELOG.md and two open PRs should never edit the same file; the release notes line can be added when the next release is cut.

Merging is just the **Merge pull request** button — this is independent of #11, either order works.
