### PR TITLE
Health Record: remove individual flights from the record

### DIFF
--- a/src/analysis/craftHistory.js
+++ b/src/analysis/craftHistory.js
@@ -150,6 +150,32 @@ if (craftKey === "Unknown craft") {
   return craftKey;
 }
 
+export function deleteFlight(storage, craftName, fileName) {
+  const history = loadHistory(storage);
+  const flights = history[craftName];
+
+  if (!Array.isArray(flights)) {
+    return false;
+  }
+
+  const remaining = flights.filter(
+    (flight) => flight.fileName !== fileName
+  );
+
+  if (remaining.length === flights.length) {
+    return false;
+  }
+
+  if (remaining.length === 0) {
+    delete history[craftName];
+  } else {
+    history[craftName] = remaining;
+  }
+
+  saveHistory(storage, history);
+  return true;
+}
+
 export function clearHistory(storage) {
   storage.removeItem(STORAGE_KEY);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -544,6 +544,22 @@ body.advanced-mode details.advanced-block {
   white-space: nowrap;
 }
 
+.history-remove {
+  background: none;
+  border: none;
+  color: var(--ink-muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  line-height: 1;
+}
+
+.history-remove:hover {
+  color: var(--attention);
+  background: rgba(255, 138, 107, 0.12);
+}
+
 /* ---------------- log quality ---------------- */
 
 .quality-chips {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -41,6 +41,7 @@ import {
   recordFlight,
   buildHistoryEntry,
   assessTrends,
+  deleteFlight,
   clearHistory
 } from "./analysis/craftHistory.js";
 import { analyzeGovernorLab } from "./analysis/governorLabAnalysis.js";
@@ -1662,11 +1663,11 @@ function refreshHistoryScreen(selectedCraft) {
   historyTable.innerHTML = `
     <tr>
       <th>Date</th><th>Log</th><th>Length</th><th>Vibration</th>
-      <th>Droop</th><th>Tracking</th><th>Sag</th><th>IR est.</th>
+      <th>Droop</th><th>Tracking</th><th>Sag</th><th>IR est.</th><th></th>
     </tr>
     ${entries
       .map(
-        (entry) => `
+        (entry, index) => `
       <tr>
         <td>${new Date(entry.flightDateMs).toLocaleDateString()}</td>
         <td>${entry.fileName}</td>
@@ -1676,11 +1677,42 @@ function refreshHistoryScreen(selectedCraft) {
         <td>${cell(entry.trackingScore, "/100")}</td>
         <td>${cell(entry.batterySagPercent, "%")}</td>
         <td>${cell(entry.internalResistance, " mΩ")}</td>
+        <td><button class="history-remove" data-index="${index}"
+          title="Remove this flight from the record">✕</button></td>
       </tr>`
       )
       .join("")}
   `;
 }
+
+// The table is rebuilt on every refresh, so one delegated
+// listener outlives all the rows it serves. Rows are looked up
+// by index at click time — the table and storage can't drift
+// apart because every write triggers a refresh.
+historyTable.addEventListener("click", (event) => {
+  const button = event.target.closest(".history-remove");
+
+  if (!button) {
+    return;
+  }
+
+  const craft = historyCraftSelect.value;
+  const entries = loadHistory(localStorage)[craft] ?? [];
+  const entry = entries[Number(button.dataset.index)];
+
+  if (!entry) {
+    return;
+  }
+
+  if (
+    confirm(
+      `Remove "${entry.fileName}" from the health record? Trends recompute without it.`
+    )
+  ) {
+    deleteFlight(localStorage, craft, entry.fileName);
+    refreshHistoryScreen(craft);
+  }
+});
 
 historyCraftSelect.addEventListener("change", () => {
   refreshHistoryScreen(historyCraftSelect.value);

--- a/test/compareAndHistory.test.mjs
+++ b/test/compareAndHistory.test.mjs
@@ -10,7 +10,8 @@ import {
   recordFlight,
   loadHistory,
   buildHistoryEntry,
-  assessTrends
+  assessTrends,
+  deleteFlight
 } from "../src/analysis/craftHistory.js";
 
 function fakeSpectrum(peakHz, magnitude) {
@@ -199,4 +200,64 @@ test("filter advisor classifies rotor-linked peaks and measures attenuation", ()
   const filters = advice.recommendations.filter((r) => r.priority === "filters");
   assert.ok(filters.some((r) => /RPM filter/.test(r.text)));
   assert.ok(filters.some((r) => /138 Hz/.test(r.text)));
+});
+
+test("deleteFlight removes a single flight and keeps the rest", () => {
+  const storage = memoryStorage();
+
+  const entry = (name, dateMs) =>
+    buildHistoryEntry({
+      fileName: name,
+      flightDateMs: dateMs,
+      durationSeconds: 100,
+      dataset: fakeDataset({ peakHz: 30, peakMagnitude: 5, droopRpm: 10 })
+    });
+
+  recordFlight(storage, "Test Heli", entry("a.bbl", 1000));
+  recordFlight(storage, "Test Heli", entry("b.bbl", 2000));
+
+  assert.equal(deleteFlight(storage, "Test Heli", "a.bbl"), true);
+
+  const history = loadHistory(storage);
+  assert.equal(history["Test Heli"].length, 1);
+  assert.equal(history["Test Heli"][0].fileName, "b.bbl");
+});
+
+test("deleting the last flight removes the craft entirely", () => {
+  const storage = memoryStorage();
+
+  recordFlight(
+    storage,
+    "Solo Heli",
+    buildHistoryEntry({
+      fileName: "only.bbl",
+      flightDateMs: 1000,
+      durationSeconds: 100,
+      dataset: fakeDataset({ peakHz: 30, peakMagnitude: 5, droopRpm: 10 })
+    })
+  );
+
+  assert.equal(deleteFlight(storage, "Solo Heli", "only.bbl"), true);
+  assert.deepEqual(loadHistory(storage), {});
+});
+
+test("deleteFlight leaves storage untouched on unknown craft or file", () => {
+  const storage = memoryStorage();
+
+  recordFlight(
+    storage,
+    "Test Heli",
+    buildHistoryEntry({
+      fileName: "a.bbl",
+      flightDateMs: 1000,
+      durationSeconds: 100,
+      dataset: fakeDataset({ peakHz: 30, peakMagnitude: 5, droopRpm: 10 })
+    })
+  );
+
+  const before = JSON.stringify(loadHistory(storage));
+
+  assert.equal(deleteFlight(storage, "No Such Heli", "a.bbl"), false);
+  assert.equal(deleteFlight(storage, "Test Heli", "no-such.bbl"), false);
+  assert.equal(JSON.stringify(loadHistory(storage)), before);
 });


### PR DESCRIPTION
Small quality-of-life fix that came up in use: the Health Record could only be wiped whole. One bad log in the list — a test hop, a half-recorded flight, someone else's helicopter — meant choosing between polluted trends and deleting everything.

## What's new

Every row in the **Logged Flights** table now has a ✕ button:

- Click it, confirm, and that single flight leaves the record. Trend sentences and the trend charts recompute immediately without it.
- Deleting a craft's last flight removes the craft from the picker too.
- **Clear all history** stays for the full wipe.
- Everything still lives only on the pilot's computer, same as before.

Under the hood it's one new `deleteFlight()` function in `craftHistory.js` next to the existing `clearHistory()`, plus a small table hook — with tests covering delete-one, delete-last-removes-craft, and unknown-file-leaves-storage-untouched.

Tests: 48 total, all green. Verified live in the app as well: loaded the sample flight, removed it from the record, confirmed the stored history updates and the screen falls back to the remaining craft.

Merging: just the **Merge pull request** button. This is compatible with #11 and #12 in any order — I verified locally that all three merge cleanly together and the combined test suite stays green.
