### PR TITLE
v0.3.5: release prep — ship the tuning charts and Health Record delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
   ESC temperature telemetry is read for the first time.
 - Charts in these views share their zoom — drag on one and the
   others follow. All scoring is untouched: evidence only.
+- **PID Lab: "Tracking By Headspeed Profile"** — per-bank,
+  per-axis tracking error plus an overshoot measure, because
+  helicopters behave differently at different headspeeds.
+- **Filter Lab: "Noise By Headspeed Profile"** — one spectrum
+  per governor bank from that bank's own stable flight time,
+  with peak classification and filter advice at that bank's
+  actual rpm. Rotor harmonics move with headspeed; the combined
+  spectrum can average away a peak that only one bank sees.
+  Both per-profile cards appear when a flight visits two or
+  more banks; scoring is untouched.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@
   spectrum can average away a peak that only one bank sees.
   Both per-profile cards appear when a flight visits two or
   more banks; scoring is untouched.
+- **ESC load events understand collective**: the synchronized
+  event view now includes the collective trace, and when an
+  event's collective demand nears the flight's own maximum the
+  reading becomes "Collective load" — the sag was a response to
+  the load, not necessarily evidence of a weak pack.
+- The sidebar now shows the app version.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## v0.3.5 — the tuning charts release
+
+### Added
+
+- **Per-axis tuning preset charts** (from Ben Britton's feedback):
+  the Log Viewer's single roll-only Setpoint-vs-Gyro chart is now
+  three cards — Roll, Pitch and Yaw Tuning — each with three
+  ready-made presets: Tracking (target + gyro), Feedforward check
+  (+ I-term: I near zero while tracking = FF carrying the
+  maneuver, as Rotorflight intends) and Term balance
+  (target + P/I/D). Beginner mode shows Tracking only; Advanced
+  mode lays everything out. Colors mean the same thing on every
+  chart: blue target, orange gyro, green I, amber P, magenta D.
+- **Remove individual flights from the Health Record**: every row
+  in the Logged Flights table has a ✕ button — one bad log no
+  longer means wiping the whole record. Trends recompute without
+  the removed flight; Clear all history stays for the full wipe.
+- The HTML report now includes the tracking chart for all three
+  axes (was roll only).
+
+### Fixed
+
+- The UI smoke test now asserts that all nine preset charts
+  render with scaled data.
+
 ## v0.3.4 — feedforward doctrine + release repair
 
 Builds directly on v0.3.3's scoring cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@
   the removed flight; Clear all history stays for the full wipe.
 - The HTML report now includes the tracking chart for all three
   axes (was roll only).
+- **Governor Lab: "The Worst Droop, In Context"** — the seconds
+  around the biggest dip on one linked clock: target/actual RPM
+  and error, motor output + collective, voltage + current, and
+  the log's own recorded governor P/I/D/F/Sum terms (shown only
+  when genuinely present, never estimated from throttle).
+- **ESC Lab: "Highest-Load Moments"** — the hardest-working
+  seconds with a plain-language cause each (at the limit /
+  battery sag / normal load), a synchronized view of output,
+  current + voltage, power and ESC temperature around the
+  biggest event, and stable-flight averages per governor bank.
+  ESC temperature telemetry is read for the first time.
+- Charts in these views share their zoom — drag on one and the
+  others follow. All scoring is untouched: evidence only.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blackbox-lab",
   "productName": "Blackbox Lab",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Rotorflight Blackbox analysis suite \u2014 simple first, deeper when you want it.",
   "main": "src/index.js",
   "private": true,

--- a/src/version.js
+++ b/src/version.js
@@ -7,7 +7,7 @@
 // just means silence, never an error for the pilot.
 // ======================================================
 
-export const APP_VERSION = "0.3.4";
+export const APP_VERSION = "0.3.5";
 
 const RELEASES_API =
   "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";


### PR DESCRIPTION
Quick follow-up to today's merges. The v0.3.4 release was created at the same moment #11 merged, so the installers built from that snapshot — the tuning preset charts (#12) and the Health Record per-flight delete (#13) merged *after* the tag and aren't in any downloadable build yet. Anyone on v0.3.4 doesn't have them.

This PR makes the next release ready to cut:

- `package.json` and `src/version.js` bumped together to **0.3.5** (the lockstep test enforces this now — without the bump, a v0.3.5 release would show every user a permanent "update available" banner again).
- CHANGELOG gets the **v0.3.5** section covering the preset chart grid and the per-flight delete.

Tests: 52 total, all green.

## Release steps (all in the browser)

1. **Merge pull request** below, then **Confirm merge**.
2. **Releases** page → **Draft a new release**.
3. **Choose a tag** → type exactly `v0.3.5` (with the v) → **Create new tag: v0.3.5 on publish**.
4. Title: `Blackbox Lab v0.3.5` — paste the v0.3.5 section from CHANGELOG.md as the description — **Publish release**.
5. The **Actions** tab builds the Windows/Mac/Linux installers (10–15 min). If they land on a separate draft release, open it and press **Publish**.
6. Optional check: install it — the app should say 0.3.5, no update banner, and the Log Viewer should show the Roll/Pitch/Yaw Tuning cards.

No rush on timing — v0.3.4 works fine; this just gets today's two features into people's hands.
