### PR TITLE
README: catch up with what the app does today

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Blackbox Lab is an open-source desktop application designed to make Rotorflight 
 
 ---
 
+## Download
+
+Ready-made installers for **Windows, macOS and Linux** are on the
+[Releases page](https://github.com/hillbilly1975/Blackbox_Lab/releases/latest)
+— download, install, open a log. No build tools needed.
+
+---
+
 ## What It Looks Like
 
 **Open a log — get answers, not data.** Every flight lands on a
@@ -34,18 +42,60 @@ Blackbox Lab explains what happened during the flight using plain English and pr
 
 ---
 
-## Planned Features
+## Working Today
 
-- Automatic Blackbox Analysis
-- Governor Performance Reports
-- PID Health Reports
+- **Native .bbl decoding** — open raw Blackbox files straight off
+  the flight controller, no CSV conversion. Multi-flight files
+  supported, corrupt bytes skipped gracefully.
+- **Flight Verdict** — answers first: plain-language cards with
+  status, cause, what to do, and a jump straight to the evidence.
+- **Log Quality Gate** — before analysis, the app tells you what
+  this log can and cannot answer, and which logging settings to
+  enable for more.
+- **Charts, all laid out** — gyro, headspeed & governor, throttle,
+  battery & current, and per-axis tuning presets for Roll, Pitch
+  and Yaw: tracking, feedforward check and term balance. Drag to
+  zoom; live min/max readouts follow the zoom window.
+- **Noise spectrum** — built-in FFT shows vibration by frequency
+  in the Filter Lab.
+- **Filter Advisor** — peaks classified against rotor harmonics,
+  filter attenuation measured unfiltered-vs-filtered, with
+  concrete RPM-filter recommendations — mechanics first.
+- **PID & Filter analysis** — scores, findings, confidence and
+  recommendations in plain language. Missing telemetry gives an
+  honest "could not be measured", never a fake score.
+- **Governor, ESC & Battery Labs** — droop analysis, throttle
+  headroom & saturation, voltage sag, estimated pack internal
+  resistance and consumed capacity.
+- **Compare Flights** — before vs after: "your change made the
+  biggest vibration peak 86% better."
+- **Health Record** — every analyzed flight is filed per craft
+  (locally); rising vibration or droop across flights triggers a
+  warning before something breaks. Individual flights can be
+  removed from the record.
+- **One-file reports** — verdict, findings and charts in a single
+  shareable HTML file.
+- **Beginner & Advanced modes** — calm by default, everything
+  laid out when you switch.
+- **Update check** — a quiet banner when a newer release exists.
+- **Community log sharing** — strictly opt-in and anonymized:
+  contributed logs help make the analysis smarter for everyone.
+  Off until you say yes; details in
+  [Documentation/CONTRIBUTED-DATA.md](Documentation/CONTRIBUTED-DATA.md).
+- **Sample flights** — three ready-made logs in `samples/` (with
+  documented ground truth) so you can explore without a log at
+  hand ("Try a Sample Flight" — one click). These are recordings
+  for the app — not firmware, nothing is ever written to a
+  helicopter.
+
+## On the Roadmap
+
 - Servo Activity Reports
-- ESC Performance Reports
-- Battery Performance Reports
 - Flight Playback
 - Rotorflight Configuration Review
-- Beginner & Advanced Modes
-- One-click Report Generation
+
+The longer list of ideas lives in
+[Documentation/BLACKBOX_LAB_ROADMAP.md](Documentation/BLACKBOX_LAB_ROADMAP.md).
 
 ---
 
@@ -57,36 +107,7 @@ Deeper when you want it.
 
 ---
 
-## Working Today (v0.2)
-
-- **Native .bbl decoding** — open raw Blackbox files straight off
-  the flight controller, no CSV conversion. Multi-flight files
-  supported, corrupt bytes skipped gracefully.
-- **Charts** — gyro, setpoint-vs-gyro tracking, headspeed &
-  governor, motor & power. Drag to zoom.
-- **Noise spectrum** — built-in FFT shows vibration by frequency
-  in the Filter Lab.
-- **Filter & PID analysis** — scores, findings, confidence and
-  recommendations in plain language.
-- **Flight Verdict** — answers first: plain-language cards with
-  status, cause, what to do, and a jump straight to the evidence.
-- **Governor, ESC & Battery Labs** — droop analysis, throttle
-  headroom & saturation, voltage sag, estimated pack internal
-  resistance and consumed capacity.
-- **Compare Flights** — before vs after: "your change made the
-  biggest vibration peak 86% better."
-- **Health Record** — every analyzed flight is filed per craft
-  (locally); rising vibration or droop across flights triggers a
-  warning before something breaks.
-- **One-file reports** — verdict, findings and charts in a single
-  shareable HTML file.
-- **Sample flights** — three ready-made logs in `samples/` (with
-  documented ground truth) so you can explore without a log at
-  hand ("Try a Sample Flight" — one click). These are recordings
-  for the app — not firmware, nothing is ever written to a
-  helicopter.
-
-## Quick Start
+## Running From Source (developers)
 
 ```
 npm install


### PR DESCRIPTION
The README was still telling the v0.2 story: the Planned Features list promised seven things that have long since shipped (automatic analysis, governor/PID/ESC/battery reports, beginner & advanced modes, one-click reports…), the feature list stopped at "Working Today (v0.2)", and Quick Start told pilots to run `npm install` when the Releases page has real installers now.

What changed:

- **Download section up top** — pilots get pointed at the Releases installers first; the npm steps moved down under "Running From Source (developers)".
- **Working Today** brought current: Log Quality Gate, Filter Advisor with RPM-filter recommendations, the per-axis tuning preset charts, honest insufficient-data scoring, update check, the opt-in anonymized log sharing (linked to CONTRIBUTED-DATA.md), and the Health Record with per-flight remove.
- **Planned Features → On the Roadmap**, trimmed to what's genuinely still ahead (Servo Activity Reports, Flight Playback, Configuration Review) with a link to your full roadmap doc.
- Screenshots, Mission and Design Philosophy untouched — no version number in the headings anymore, so this doesn't go stale with every release.

Words only, no code — safe to merge anytime with the button. If it merges before v0.3.5 is tagged, the new release even ships with a current README on the release page.
