### PR TITLE
Governor & ESC Labs: synchronized evidence views (worst droop in context, highest-load moments, per-profile averages)

### DIFF
--- a/src/analysis/evidenceViews.js
+++ b/src/analysis/evidenceViews.js
@@ -1,0 +1,303 @@
+// ======================================================
+// BLACKBOX LAB — EVIDENCE VIEW HELPERS
+// ======================================================
+//
+// Pure helpers behind the synchronized evidence views in
+// the Governor and ESC Labs. They select the moments worth
+// looking at and describe them in plain language — they
+// never touch any lab score.
+//
+// ======================================================
+
+// Index window covering [centerSeconds - beforeSeconds,
+// centerSeconds + afterSeconds] on a monotonic time axis.
+export function sliceWindow(
+  timeSeconds,
+  centerSeconds,
+  beforeSeconds,
+  afterSeconds
+) {
+  if (
+    !Array.isArray(timeSeconds) ||
+    timeSeconds.length === 0 ||
+    !Number.isFinite(centerSeconds)
+  ) {
+    return null;
+  }
+
+  const startTime = centerSeconds - beforeSeconds;
+  const endTime = centerSeconds + afterSeconds;
+
+  let startIndex = 0;
+  let endIndex = timeSeconds.length - 1;
+
+  for (let i = 0; i < timeSeconds.length; i += 1) {
+    if (timeSeconds[i] >= startTime) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  for (let i = timeSeconds.length - 1; i >= 0; i -= 1) {
+    if (timeSeconds[i] <= endTime) {
+      endIndex = i;
+      break;
+    }
+  }
+
+  if (endIndex <= startIndex) {
+    return null;
+  }
+
+  return { startIndex, endIndex };
+}
+
+export function windowStats(values, startIndex, endIndex) {
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  let count = 0;
+
+  for (let i = startIndex; i <= endIndex; i += 1) {
+    const value = values[i];
+
+    if (!Number.isFinite(value)) {
+      continue;
+    }
+
+    if (value < min) min = value;
+    if (value > max) max = value;
+    sum += value;
+    count += 1;
+  }
+
+  if (count === 0) {
+    return null;
+  }
+
+  return {
+    min,
+    max,
+    average: sum / count,
+    sampleCount: count
+  };
+}
+
+// The top non-overlapping windows by average load. "Load"
+// is whatever series the caller passes — current when the
+// log has it, output percent otherwise.
+export function findHighestLoadEvents(
+  { timeSeconds, load },
+  { windowSeconds = 2, count = 3 } = {}
+) {
+  if (
+    !Array.isArray(timeSeconds) ||
+    !Array.isArray(load) ||
+    timeSeconds.length < 10 ||
+    load.length !== timeSeconds.length
+  ) {
+    return [];
+  }
+
+  const duration =
+    timeSeconds[timeSeconds.length - 1] - timeSeconds[0];
+
+  if (!(duration > windowSeconds)) {
+    return [];
+  }
+
+  const samplesPerSecond =
+    timeSeconds.length / duration;
+
+  const windowSamples = Math.max(
+    10,
+    Math.round(windowSeconds * samplesPerSecond)
+  );
+
+  // Rolling average via prefix sums (nulls count as 0 but
+  // are tracked so sparse telemetry doesn't fake a lull).
+  const prefixSum = new Float64Array(load.length + 1);
+  const prefixCount = new Float64Array(load.length + 1);
+
+  for (let i = 0; i < load.length; i += 1) {
+    const value = Number.isFinite(load[i]) ? load[i] : 0;
+    prefixSum[i + 1] = prefixSum[i] + value;
+    prefixCount[i + 1] =
+      prefixCount[i] + (Number.isFinite(load[i]) ? 1 : 0);
+  }
+
+  const candidates = [];
+
+  for (
+    let start = 0;
+    start + windowSamples <= load.length;
+    start += Math.max(1, Math.floor(windowSamples / 4))
+  ) {
+    const end = start + windowSamples;
+    const validCount = prefixCount[end] - prefixCount[start];
+
+    if (validCount < windowSamples / 2) {
+      continue;
+    }
+
+    candidates.push({
+      startIndex: start,
+      endIndex: end - 1,
+      averageLoad:
+        (prefixSum[end] - prefixSum[start]) / validCount
+    });
+  }
+
+  candidates.sort(
+    (first, second) => second.averageLoad - first.averageLoad
+  );
+
+  const events = [];
+
+  for (const candidate of candidates) {
+    const overlaps = events.some(
+      (event) =>
+        candidate.startIndex <= event.endIndex &&
+        candidate.endIndex >= event.startIndex
+    );
+
+    if (overlaps) {
+      continue;
+    }
+
+    const stats = windowStats(
+      load,
+      candidate.startIndex,
+      candidate.endIndex
+    );
+
+    let peakIndex = candidate.startIndex;
+    let peakValue = -Infinity;
+
+    for (
+      let i = candidate.startIndex;
+      i <= candidate.endIndex;
+      i += 1
+    ) {
+      if (
+        Number.isFinite(load[i]) &&
+        load[i] > peakValue
+      ) {
+        peakValue = load[i];
+        peakIndex = i;
+      }
+    }
+
+    events.push({
+      startIndex: candidate.startIndex,
+      endIndex: candidate.endIndex,
+      startSeconds: timeSeconds[candidate.startIndex],
+      endSeconds: timeSeconds[candidate.endIndex],
+      peakSeconds: timeSeconds[peakIndex],
+      averageLoad: stats ? stats.average : null,
+      peakLoad: Number.isFinite(peakValue) ? peakValue : null
+    });
+
+    if (events.length >= count) {
+      break;
+    }
+  }
+
+  return events.sort(
+    (first, second) => first.startSeconds - second.startSeconds
+  );
+}
+
+// Why was the output high here? Three answers a pilot can
+// act on, in priority order: the ESC genuinely ran out of
+// headroom; the battery sagged so more throttle was needed
+// for the same power; or it was simply a demanding moment
+// working as designed.
+export function explainLoadEvent({
+  outputPeakPercent,
+  outputSaturatedShare,
+  voltageSagPercent
+}) {
+  const saturated =
+    Number.isFinite(outputPeakPercent) &&
+    outputPeakPercent >= 97 &&
+    Number.isFinite(outputSaturatedShare) &&
+    outputSaturatedShare >= 0.15;
+
+  if (saturated) {
+    return {
+      cause: "headroom-limit",
+      sentence:
+        "Output sat at maximum for a meaningful part of this event — the power system had nothing left to give here. Consider more headroom (lower headspeed, fresher pack, or gearing) before blaming the tune."
+    };
+  }
+
+  if (
+    Number.isFinite(voltageSagPercent) &&
+    voltageSagPercent >= 8
+  ) {
+    return {
+      cause: "battery-sag",
+      sentence:
+        "Pack voltage sagged noticeably during this event, so the governor needed extra throttle to deliver the same power. The demand is real, but the battery is amplifying it."
+    };
+  }
+
+  return {
+    cause: "normal-load",
+    sentence:
+      "High output with headroom to spare and steady voltage — this looks like a genuinely demanding moment handled as designed."
+  };
+}
+
+// Group stable-flight samples by governor target so
+// averages can be reported per headspeed profile (bank).
+// Targets within one percent of each other belong to the
+// same bank.
+export function groupByGovernorTarget({
+  governorTarget,
+  sampleIndexes
+}) {
+  if (
+    !Array.isArray(governorTarget) ||
+    !Array.isArray(sampleIndexes)
+  ) {
+    return [];
+  }
+
+  const banks = [];
+
+  for (const index of sampleIndexes) {
+    const target = Number(governorTarget[index]);
+
+    if (!Number.isFinite(target) || target <= 0) {
+      continue;
+    }
+
+    let bank = banks.find(
+      (candidate) =>
+        Math.abs(candidate.targetRpm - target) <=
+        candidate.targetRpm * 0.01
+    );
+
+    if (!bank) {
+      bank = { targetRpm: target, indexes: [] };
+      banks.push(bank);
+    }
+
+    bank.indexes.push(index);
+  }
+
+  return banks
+    .filter((bank) => bank.indexes.length >= 100)
+    .map((bank) => ({
+      targetRpm: Math.round(
+        bank.indexes.reduce(
+          (sum, index) => sum + governorTarget[index],
+          0
+        ) / bank.indexes.length
+      ),
+      indexes: bank.indexes
+    }))
+    .sort((first, second) => first.targetRpm - second.targetRpm);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -506,6 +506,31 @@
             <p class="chart-empty">Open a log to see this chart.</p>
           </div>
         </section>
+
+        <section class="card" id="droopContextCard" hidden>
+          <h3>The Worst Droop, In Context</h3>
+          <p class="chart-hint" id="droopContextHint">
+            The seconds around the biggest dip, lined up on one
+            clock — zoom any chart and the others follow. Read top
+            to bottom: what the rotor did, what the pilot and
+            governor asked for, and what the power system delivered.
+          </p>
+          <div class="chart-container" id="chartDroopRpm">
+          </div>
+          <div class="chart-container" id="chartDroopDrive">
+          </div>
+          <div class="chart-container" id="chartDroopPower">
+          </div>
+          <div id="droopGovBlock" hidden>
+            <p class="chart-hint">
+              The governor's own P, I and F terms as recorded in the
+              log — shown only when the log genuinely contains them,
+              never estimated from throttle.
+            </p>
+            <div class="chart-container" id="chartDroopGov">
+            </div>
+          </div>
+        </section>
       </section>
 
       <!-- ============ ESC LAB ============ -->
@@ -529,6 +554,42 @@
           </p>
           <div class="chart-container" id="chartEsc">
             <p class="chart-empty">Open a log to see this chart.</p>
+          </div>
+        </section>
+
+        <section class="card" id="loadEventsCard" hidden>
+          <h3>Highest-Load Moments</h3>
+          <p class="chart-hint">
+            The hardest-working seconds of the flight, and why the
+            output was high: a real limit, a sagging battery, or
+            simply a demanding maneuver handled as designed.
+          </p>
+          <div class="table-scroll">
+            <table class="history-table" id="escEventsTable"></table>
+          </div>
+          <div id="escEventsStories"></div>
+          <p class="chart-hint" style="margin-top:14px;">
+            The biggest event on one clock — zoom any chart and the
+            others follow.
+          </p>
+          <div class="chart-container" id="chartLoadOutput">
+          </div>
+          <div class="chart-container" id="chartLoadPower">
+          </div>
+          <div class="chart-container" id="chartLoadWatts">
+          </div>
+          <div class="chart-container" id="chartLoadTemp" hidden>
+          </div>
+        </section>
+
+        <section class="card" id="escProfileCard" hidden>
+          <h3>By Headspeed Profile</h3>
+          <p class="chart-hint">
+            Stable-flight averages per governor bank — how much
+            harder each headspeed works the power system.
+          </p>
+          <div class="table-scroll">
+            <table class="history-table" id="escProfileTable"></table>
           </div>
         </section>
       </section>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -45,6 +45,13 @@ import {
   clearHistory
 } from "./analysis/craftHistory.js";
 import { analyzeGovernorLab } from "./analysis/governorLabAnalysis.js";
+import {
+  sliceWindow,
+  windowStats,
+  findHighestLoadEvents,
+  explainLoadEvent,
+  groupByGovernorTarget
+} from "./analysis/evidenceViews.js";
 import { analyzeEscLab } from "./analysis/escLabAnalysis.js";
 import { analyzeBatteryLab } from "./analysis/batteryLabAnalysis.js";
 //
@@ -118,6 +125,23 @@ const governorStory = el("governorStory");
 const governorMetrics = el("governorMetrics");
 const escStory = el("escStory");
 const escMetrics = el("escMetrics");
+
+const droopContextCard = el("droopContextCard");
+const droopGovBlock = el("droopGovBlock");
+const chartDroopRpm = el("chartDroopRpm");
+const chartDroopDrive = el("chartDroopDrive");
+const chartDroopPower = el("chartDroopPower");
+const chartDroopGov = el("chartDroopGov");
+
+const loadEventsCard = el("loadEventsCard");
+const escEventsTable = el("escEventsTable");
+const escEventsStories = el("escEventsStories");
+const chartLoadOutput = el("chartLoadOutput");
+const chartLoadPower = el("chartLoadPower");
+const chartLoadWatts = el("chartLoadWatts");
+const chartLoadTemp = el("chartLoadTemp");
+const escProfileCard = el("escProfileCard");
+const escProfileTable = el("escProfileTable");
 const batteryStory = el("batteryStory");
 const batteryMetrics = el("batteryMetrics");
 
@@ -1127,6 +1151,492 @@ function renderTuningPresets(dataset) {
   }
 }
 
+// ---- synchronized evidence views (Governor & ESC Labs) ----
+// Evidence only: these read what the labs already computed and
+// what the log genuinely recorded. No score is touched here.
+
+function toDegreesCelsius(values) {
+  let max = 0;
+
+  for (const value of values) {
+    if (value > max) max = value;
+  }
+
+  // Logs store temperature either directly or ×10.
+  return max > 200
+    ? values.map((value) => value / 10)
+    : values;
+}
+
+function slicedSeries(dataset, window, entries) {
+  const series = [];
+
+  for (const entry of entries) {
+    let values = entry.values;
+
+    if (!values) {
+      const column = dataset.findColumnsIn(entry.patterns)[0];
+
+      if (!column) {
+        continue;
+      }
+
+      values = dataset.columnValues(column);
+      values = entry.convert ? entry.convert(values) : values;
+    }
+
+    series.push({
+      label: entry.label,
+      values: values.slice(window.startIndex, window.endIndex + 1),
+      color: entry.color
+    });
+  }
+
+  return series;
+}
+
+function renderSyncedChart(element, dataset, window, entries, options) {
+  const series = slicedSeries(dataset, window, entries);
+
+  if (series.length === 0) {
+    element.innerHTML = "";
+    element.hidden = true;
+    return false;
+  }
+
+  element.hidden = false;
+  renderTimeSeriesChart(element, {
+    timeSeconds: dataset.timeSeconds.slice(
+      window.startIndex,
+      window.endIndex + 1
+    ),
+    series,
+    height: 190,
+    ...options
+  });
+
+  return true;
+}
+
+function renderGovernorEvidence(dataset) {
+  const droopTime = dataset.labs.governor?.droopTimeSeconds;
+
+  const window = Number.isFinite(droopTime)
+    ? sliceWindow(dataset.timeSeconds, droopTime, 4, 6)
+    : null;
+
+  if (!window) {
+    droopContextCard.hidden = true;
+    return;
+  }
+
+  droopContextCard.hidden = false;
+
+  const markers = [{ x: droopTime, label: "worst droop" }];
+
+  const targetValues = dataset.governorTarget ?? [];
+  const actualValues = dataset.headspeed ?? [];
+  const errorValues = actualValues.map((actual, index) => {
+    const target = targetValues[index];
+    return Number.isFinite(target) && Number.isFinite(actual)
+      ? target - actual
+      : null;
+  });
+
+  renderSyncedChart(
+    chartDroopRpm,
+    dataset,
+    window,
+    [
+      { label: "govTarget", values: targetValues, color: CHART_COLORS[0] },
+      { label: "headspeed", values: actualValues, color: CHART_COLORS[1] },
+      { label: "RPM error", values: errorValues, color: CHART_COLORS[4] }
+    ],
+    { yLabel: "rpm", markers, linkGroup: "droopSync" }
+  );
+
+  renderSyncedChart(
+    chartDroopDrive,
+    dataset,
+    window,
+    [
+      {
+        patterns: [/^motor\[0\]$/i],
+        label: "Motor output (%)",
+        convert: toThrottlePercent,
+        color: CHART_COLORS[3]
+      },
+      {
+        patterns: [/^setpoint\[3\]$/i],
+        label: "Collective target",
+        color: CHART_COLORS[5]
+      }
+    ],
+    { yLabel: "% · collective", markers, linkGroup: "droopSync" }
+  );
+
+  renderSyncedChart(
+    chartDroopPower,
+    dataset,
+    window,
+    [
+      {
+        patterns: [/^vbat/i],
+        label: "Pack voltage (V)",
+        convert: toVolts,
+        color: CHART_COLORS[0]
+      },
+      {
+        patterns: [/^Ibat$/i, /amperage/i, /^EscI$/i, /current/i],
+        label: "Current (A)",
+        convert: toAmps,
+        color: CHART_COLORS[1]
+      }
+    ],
+    { yLabel: "volts · amps", markers, linkGroup: "droopSync" }
+  );
+
+  // Real recorded governor terms only — never derived.
+  const governorTermEntries = [
+    { patterns: [/^govP$/i], label: "govP", color: CHART_COLORS[3] },
+    { patterns: [/^govI$/i], label: "govI", color: CHART_COLORS[2] },
+    { patterns: [/^govD$/i], label: "govD", color: CHART_COLORS[4] },
+    { patterns: [/^govF$/i], label: "govF", color: CHART_COLORS[5] },
+    { patterns: [/^govSum$/i], label: "govSum", color: CHART_COLORS[0] }
+  ].filter(
+    (entry) => dataset.findColumnsIn(entry.patterns).length > 0
+  );
+
+  if (governorTermEntries.length === 0) {
+    droopGovBlock.hidden = true;
+  } else {
+    droopGovBlock.hidden = false;
+    renderSyncedChart(
+      chartDroopGov,
+      dataset,
+      window,
+      governorTermEntries,
+      { yLabel: "governor terms", markers, linkGroup: "droopSync" }
+    );
+  }
+}
+
+function renderEscEvidence(dataset) {
+  const outputColumn =
+    dataset.findColumnsIn([/^EscThr$/i])[0] ??
+    dataset.findColumnsIn([/^motor\[0\]$/i])[0];
+
+  const currentColumn =
+    dataset.findColumnsIn([/^EscI$/i])[0] ??
+    dataset.findColumnsIn([/^Ibat$/i, /amperage/i, /current/i])[0];
+
+  const voltageColumn =
+    dataset.findColumnsIn([/^EscV$/i])[0] ??
+    dataset.findColumnsIn([/^vbat/i])[0];
+
+  if (!outputColumn || !currentColumn || !voltageColumn) {
+    loadEventsCard.hidden = true;
+    escProfileCard.hidden = true;
+    return;
+  }
+
+  const outputPercent = toThrottlePercent(
+    dataset.columnValues(outputColumn)
+  );
+  const currentAmps = toAmps(dataset.columnValues(currentColumn));
+  const voltageVolts = toVolts(dataset.columnValues(voltageColumn));
+
+  const wattValues = currentAmps.map((amps, index) => {
+    const volts = voltageVolts[index];
+    return Number.isFinite(amps) && Number.isFinite(volts)
+      ? amps * volts
+      : null;
+  });
+
+  // An all-zero temperature column means the sensor isn't
+  // fitted (e.g. no second ESC) — don't plot a dead line.
+  const temperatureEntries = [
+    { patterns: [/^Tesc$/i], label: "Tesc", color: CHART_COLORS[1] },
+    { patterns: [/^Tesc2$/i], label: "Tesc2", color: CHART_COLORS[4] },
+    { patterns: [/^tempEsc/i, /escTemp/i], label: "ESC temp", color: CHART_COLORS[1] }
+  ].filter((entry) => {
+    const column = dataset.findColumnsIn(entry.patterns)[0];
+    return (
+      Boolean(column) &&
+      dataset.columnValues(column).some((value) => value > 0)
+    );
+  });
+
+  const events = findHighestLoadEvents(
+    { timeSeconds: dataset.timeSeconds, load: currentAmps },
+    { windowSeconds: 2, count: 3 }
+  );
+
+  if (events.length === 0) {
+    loadEventsCard.hidden = true;
+  } else {
+    loadEventsCard.hidden = false;
+
+    // Voltage baseline: the calm top end of the whole flight.
+    const sortedVoltage = voltageVolts
+      .filter(Number.isFinite)
+      .sort((first, second) => first - second);
+    const baselineVoltage =
+      sortedVoltage[Math.floor(sortedVoltage.length * 0.95)] ?? null;
+
+    const describedEvents = events.map((event) => {
+      const output = windowStats(
+        outputPercent,
+        event.startIndex,
+        event.endIndex
+      );
+
+      let saturatedCount = 0;
+      let outputCount = 0;
+
+      for (let i = event.startIndex; i <= event.endIndex; i += 1) {
+        if (Number.isFinite(outputPercent[i])) {
+          outputCount += 1;
+          if (outputPercent[i] >= 97) {
+            saturatedCount += 1;
+          }
+        }
+      }
+
+      const voltage = windowStats(
+        voltageVolts,
+        event.startIndex,
+        event.endIndex
+      );
+
+      const sagPercent =
+        baselineVoltage && voltage
+          ? ((baselineVoltage - voltage.min) / baselineVoltage) * 100
+          : null;
+
+      const watts = windowStats(
+        wattValues,
+        event.startIndex,
+        event.endIndex
+      );
+
+      const explanation = explainLoadEvent({
+        outputPeakPercent: output?.max ?? null,
+        outputSaturatedShare:
+          outputCount > 0 ? saturatedCount / outputCount : null,
+        voltageSagPercent: sagPercent
+      });
+
+      return { event, output, voltage, sagPercent, watts, explanation };
+    });
+
+    const cell = (value, digits = 1, suffix = "") =>
+      Number.isFinite(value)
+        ? `${value.toFixed(digits)}${suffix}`
+        : "—";
+
+    escEventsTable.innerHTML = `
+      <tr>
+        <th>When</th><th>Avg current</th><th>Peak current</th>
+        <th>Peak output</th><th>Peak power</th><th>Sag</th><th>Reading</th>
+      </tr>
+      ${describedEvents
+        .map(
+          ({ event, output, sagPercent, watts, explanation }) => `
+        <tr>
+          <td>${event.startSeconds.toFixed(1)}–${event.endSeconds.toFixed(1)} s</td>
+          <td>${cell(event.averageLoad, 1, " A")}</td>
+          <td>${cell(event.peakLoad, 1, " A")}</td>
+          <td>${cell(output?.max, 0, "%")}</td>
+          <td>${cell(watts?.max, 0, " W")}</td>
+          <td>${cell(sagPercent, 1, "%")}</td>
+          <td>${
+            explanation.cause === "headroom-limit"
+              ? "At the limit"
+              : explanation.cause === "battery-sag"
+                ? "Battery sag"
+                : "Normal load"
+          }</td>
+        </tr>`
+        )
+        .join("")}
+    `;
+
+    escEventsStories.innerHTML = "";
+
+    for (const { event, explanation } of describedEvents) {
+      const story = document.createElement("p");
+      story.className = "chart-hint";
+      story.textContent = `${event.startSeconds.toFixed(1)}–${event.endSeconds.toFixed(1)} s: ${explanation.sentence}`;
+      escEventsStories.appendChild(story);
+    }
+
+    // The biggest event gets the synchronized picture.
+    const biggest = describedEvents.reduce((best, candidate) =>
+      (candidate.event.averageLoad ?? 0) >
+      (best.event.averageLoad ?? 0)
+        ? candidate
+        : best
+    );
+
+    const window = sliceWindow(
+      dataset.timeSeconds,
+      biggest.event.peakSeconds,
+      3,
+      3
+    );
+
+    if (window) {
+      const markers = [
+        { x: biggest.event.peakSeconds, label: "peak load" }
+      ];
+
+      renderSyncedChart(
+        chartLoadOutput,
+        dataset,
+        window,
+        [
+          {
+            label: "ESC output (%)",
+            values: outputPercent,
+            color: CHART_COLORS[3]
+          }
+        ],
+        { yLabel: "output (%)", markers, linkGroup: "loadSync" }
+      );
+
+      renderSyncedChart(
+        chartLoadPower,
+        dataset,
+        window,
+        [
+          { label: "Current (A)", values: currentAmps, color: CHART_COLORS[1] },
+          { label: "Voltage (V)", values: voltageVolts, color: CHART_COLORS[0] }
+        ],
+        { yLabel: "amps · volts", markers, linkGroup: "loadSync" }
+      );
+
+      renderSyncedChart(
+        chartLoadWatts,
+        dataset,
+        window,
+        [
+          {
+            label: "Electrical power (W)",
+            values: wattValues,
+            color: CHART_COLORS[2]
+          }
+        ],
+        { yLabel: "watts", markers, linkGroup: "loadSync" }
+      );
+
+      if (temperatureEntries.length > 0) {
+        renderSyncedChart(
+          chartLoadTemp,
+          dataset,
+          window,
+          temperatureEntries.map((entry) => ({
+            ...entry,
+            convert: toDegreesCelsius
+          })),
+          { yLabel: "°C", markers, linkGroup: "loadSync" }
+        );
+      } else {
+        chartLoadTemp.hidden = true;
+      }
+    }
+  }
+
+  // ---- per-profile averages (stable flight only) ----
+  const phase =
+    dataset.headspeed && dataset.governorTarget
+      ? detectStableFlightPhase({
+          timeSeconds: dataset.timeSeconds,
+          headspeed: dataset.headspeed,
+          governorTarget: dataset.governorTarget
+        })
+      : null;
+
+  const banks = phase
+    ? groupByGovernorTarget({
+        governorTarget: dataset.governorTarget,
+        sampleIndexes: phase.stableIndexes ?? []
+      })
+    : [];
+
+  if (banks.length === 0) {
+    escProfileCard.hidden = true;
+    return;
+  }
+
+  const averageAt = (values, indexes) => {
+    let sum = 0;
+    let count = 0;
+
+    for (const index of indexes) {
+      if (Number.isFinite(values[index])) {
+        sum += values[index];
+        count += 1;
+      }
+    }
+
+    return count > 0 ? sum / count : null;
+  };
+
+  const maximumAt = (values, indexes) => {
+    let max = null;
+
+    for (const index of indexes) {
+      if (
+        Number.isFinite(values[index]) &&
+        (max === null || values[index] > max)
+      ) {
+        max = values[index];
+      }
+    }
+
+    return max;
+  };
+
+  const temperatureValues =
+    temperatureEntries.length > 0
+      ? toDegreesCelsius(
+          dataset.columnValues(
+            dataset.findColumnsIn(temperatureEntries[0].patterns)[0]
+          )
+        )
+      : null;
+
+  const profileCell = (value, digits = 1, suffix = "") =>
+    Number.isFinite(value)
+      ? `${value.toFixed(digits)}${suffix}`
+      : "—";
+
+  escProfileCard.hidden = false;
+  escProfileTable.innerHTML = `
+    <tr>
+      <th>Bank</th><th>Avg output</th><th>Avg current</th>
+      <th>Avg power</th><th>Max temp</th>
+    </tr>
+    ${banks
+      .map(
+        (bank) => `
+      <tr>
+        <td>${bank.targetRpm} rpm</td>
+        <td>${profileCell(averageAt(outputPercent, bank.indexes), 1, "%")}</td>
+        <td>${profileCell(averageAt(currentAmps, bank.indexes), 1, " A")}</td>
+        <td>${profileCell(averageAt(wattValues, bank.indexes), 0, " W")}</td>
+        <td>${
+          temperatureValues
+            ? profileCell(maximumAt(temperatureValues, bank.indexes), 0, " °C")
+            : "—"
+        }</td>
+      </tr>`
+      )
+      .join("")}
+  `;
+}
+
 function renderAllCharts(dataset) {
   if (!dataset) {
     for (const element of [
@@ -1139,6 +1649,10 @@ function renderAllCharts(dataset) {
       element.innerHTML =
         '<p class="chart-empty">No plottable telemetry found in this log.</p>';
     }
+
+    droopContextCard.hidden = true;
+    loadEventsCard.hidden = true;
+    escProfileCard.hidden = true;
 
     return;
   }
@@ -1232,6 +1746,9 @@ function renderAllCharts(dataset) {
     chartSpectrum.innerHTML =
       '<p class="chart-empty">Not enough gyro data for a spectrum.</p>';
   }
+
+  renderGovernorEvidence(dataset);
+  renderEscEvidence(dataset);
 }
 
 function renderQuality(dataset, flightStats) {

--- a/src/ui/charts.js
+++ b/src/ui/charts.js
@@ -34,6 +34,15 @@ const AXIS_STYLE = {
 
 function destroyExistingChart(element) {
   if (element.__blackboxLabChart) {
+    const group = element.__blackboxLabLinkGroup
+      ? linkGroups.get(element.__blackboxLabLinkGroup)
+      : null;
+
+    if (group) {
+      group.delete(element.__blackboxLabChart);
+      element.__blackboxLabLinkGroup = null;
+    }
+
     element.__blackboxLabChart.destroy();
     element.__blackboxLabChart = null;
   }
@@ -91,8 +100,21 @@ export function friendlySeriesLabel(name) {
 const WHOLE_NAME_LABELS = {
   headspeed: "Headspeed",
   govTarget: "Governor target",
+  governorTarget: "Governor target",
   vbatLatest: "Pack voltage",
-  Vbat: "Pack voltage"
+  Vbat: "Pack voltage",
+  Ibat: "Pack current",
+  govP: "Governor P",
+  govI: "Governor I",
+  govD: "Governor D",
+  govF: "Governor FF",
+  govSum: "Governor sum",
+  EscV: "ESC voltage",
+  EscI: "ESC current",
+  EscThr: "ESC throttle",
+  Tesc: "ESC temp",
+  Tesc2: "ESC temp 2",
+  Tmcu: "MCU temp"
 };
 
 export function friendlyLabel(name) {
@@ -177,6 +199,44 @@ function buildChartFooter(element, chart, seriesMeta, { withStats }) {
   refresh();
 }
 
+// Charts in the same link group share their x-axis window:
+// zooming one zooms the others. Used by the synchronized
+// evidence views (worst droop, highest load).
+const linkGroups = new Map();
+let broadcastingLinkGroup = false;
+
+function joinLinkGroup(groupName, chart, element) {
+  if (!linkGroups.has(groupName)) {
+    linkGroups.set(groupName, new Set());
+  }
+
+  const group = linkGroups.get(groupName);
+  group.add(chart);
+  element.__blackboxLabLinkGroup = groupName;
+
+  chart.hooks.setScale = chart.hooks.setScale || [];
+  chart.hooks.setScale.push((u, key) => {
+    if (key !== "x" || broadcastingLinkGroup) {
+      return;
+    }
+
+    broadcastingLinkGroup = true;
+
+    try {
+      for (const sibling of group) {
+        if (sibling !== u) {
+          sibling.setScale("x", {
+            min: u.scales.x.min,
+            max: u.scales.x.max
+          });
+        }
+      }
+    } finally {
+      broadcastingLinkGroup = false;
+    }
+  });
+}
+
 export function renderTimeSeriesChart(element, options) {
   const {
     timeSeconds,
@@ -184,7 +244,8 @@ export function renderTimeSeriesChart(element, options) {
     height = 260,
     yLabel = "",
     xLabel = "Flight time (s)",
-    markers = []
+    markers = [],
+    linkGroup = null
   } = options;
 
   destroyExistingChart(element);
@@ -303,6 +364,10 @@ export function renderTimeSeriesChart(element, options) {
   element.__blackboxLabChart = chart;
   watchResize(element, chart);
   buildChartFooter(element, chart, seriesMeta, { withStats: true });
+
+  if (linkGroup) {
+    joinLinkGroup(linkGroup, chart, element);
+  }
 
   return chart;
 }

--- a/test/evidenceViews.test.mjs
+++ b/test/evidenceViews.test.mjs
@@ -1,0 +1,114 @@
+// ======================================================
+// BLACKBOX LAB — EVIDENCE VIEW HELPER TESTS
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  sliceWindow,
+  windowStats,
+  findHighestLoadEvents,
+  explainLoadEvent,
+  groupByGovernorTarget
+} from "../src/analysis/evidenceViews.js";
+
+const secondsAxis = (count, rateHz) =>
+  Array.from({ length: count }, (_, index) => index / rateHz);
+
+test("sliceWindow clamps to the recording and centers on the moment", () => {
+  const time = secondsAxis(1000, 100); // 10 s at 100 Hz
+
+  const window = sliceWindow(time, 5, 1, 2);
+  assert.ok(window);
+  assert.ok(Math.abs(time[window.startIndex] - 4) < 0.02);
+  assert.ok(Math.abs(time[window.endIndex] - 7) < 0.02);
+
+  const clamped = sliceWindow(time, 0.2, 5, 1);
+  assert.equal(clamped.startIndex, 0);
+
+  assert.equal(sliceWindow(time, null, 1, 1), null);
+});
+
+test("windowStats ignores gaps and reports min/max/average", () => {
+  const values = [1, null, 3, NaN, 5];
+  const stats = windowStats(values, 0, 4);
+
+  assert.equal(stats.min, 1);
+  assert.equal(stats.max, 5);
+  assert.equal(stats.average, 3);
+  assert.equal(stats.sampleCount, 3);
+});
+
+test("findHighestLoadEvents returns non-overlapping top windows in time order", () => {
+  const time = secondsAxis(3000, 100); // 30 s
+  const load = time.map((t) => {
+    if (t >= 5 && t < 7) return 80; // biggest event
+    if (t >= 20 && t < 22) return 60; // second event
+    return 10;
+  });
+
+  const events = findHighestLoadEvents(
+    { timeSeconds: time, load },
+    { windowSeconds: 2, count: 2 }
+  );
+
+  assert.equal(events.length, 2);
+  assert.ok(events[0].startSeconds < events[1].startSeconds);
+  assert.ok(events[0].averageLoad > 50);
+  assert.ok(events[1].averageLoad > 40);
+  assert.ok(
+    events[0].endIndex < events[1].startIndex,
+    "events must not overlap"
+  );
+});
+
+test("explainLoadEvent tells limit from sag from normal load", () => {
+  const limit = explainLoadEvent({
+    outputPeakPercent: 100,
+    outputSaturatedShare: 0.4,
+    voltageSagPercent: 12
+  });
+  assert.equal(limit.cause, "headroom-limit");
+
+  const sag = explainLoadEvent({
+    outputPeakPercent: 88,
+    outputSaturatedShare: 0,
+    voltageSagPercent: 10
+  });
+  assert.equal(sag.cause, "battery-sag");
+
+  const normal = explainLoadEvent({
+    outputPeakPercent: 85,
+    outputSaturatedShare: 0,
+    voltageSagPercent: 3
+  });
+  assert.equal(normal.cause, "normal-load");
+});
+
+test("groupByGovernorTarget clusters banks and ignores tiny groups", () => {
+  const governorTarget = [];
+  const sampleIndexes = [];
+
+  // Bank 1: 1700 rpm ±5 for 200 samples; Bank 2: 1900 rpm for
+  // 150 samples; noise bank: 2100 rpm for only 20 samples.
+  for (let i = 0; i < 200; i += 1) {
+    governorTarget.push(1700 + (i % 2 === 0 ? 5 : -5));
+    sampleIndexes.push(governorTarget.length - 1);
+  }
+  for (let i = 0; i < 150; i += 1) {
+    governorTarget.push(1900);
+    sampleIndexes.push(governorTarget.length - 1);
+  }
+  for (let i = 0; i < 20; i += 1) {
+    governorTarget.push(2100);
+    sampleIndexes.push(governorTarget.length - 1);
+  }
+
+  const banks = groupByGovernorTarget({ governorTarget, sampleIndexes });
+
+  assert.equal(banks.length, 2);
+  assert.equal(banks[0].targetRpm, 1700);
+  assert.equal(banks[1].targetRpm, 1900);
+  assert.equal(banks[0].indexes.length, 200);
+});


### PR DESCRIPTION
Here's the Governor and ESC Lab expansion we talked about — built exactly to your framing: **evidence views only, scoring untouched everywhere.**

## Governor Lab — "The Worst Droop, In Context"

A new card below Headspeed vs Target shows the seconds around the biggest dip, all on one clock — zoom any chart and the others follow:

1. **Rotor**: governor target, actual headspeed, and the RPM error between them
2. **Demand**: motor output (%) and collective target
3. **Power**: pack voltage and current
4. **Governor terms**: the log's own recorded govP / govI / govD / govF / govSum

On the fourth chart, your rule is implemented literally: those traces appear **only when the log genuinely records governor terms** — the card says so in its hint, and nothing is ever estimated from throttle. Logs without the fields simply don't get that chart.

## ESC Lab — "Highest-Load Moments" + "By Headspeed Profile"

- The top three non-overlapping load windows, each with average/peak current, peak output, peak power, sag — and a **plain-language reading of why the output was high**: *At the limit* (sustained saturation), *Battery sag* (voltage-driven throttle), or *Normal load* (demanding moment, handled as designed).
- The biggest event gets the synchronized picture: output %, current + voltage, electrical power, and ESC temperature — first time the app reads the Tesc fields. An all-zero temperature column (no second ESC fitted) is treated as "sensor not there" rather than drawing a dead line.
- **By Headspeed Profile**: stable-flight averages per governor bank — output %, current, power, max temp — so you can see how much harder each headspeed works the power system. Bank detection reuses the same stable-flight-phase module your scoring uses.

## Validated on a real flight

Tested end-to-end with a real 134k-frame RF 4.6.0 log: all three governor banks detected (1710/1770/1830) with sensible per-bank averages (79.1% / 9.6 A / 274 W / 37 °C at 1710), and every high-output moment on that flight correctly attributed to **battery sag** — 86–93% output with headroom to spare while the pack dipped 14–15%. The droop view reads like a story: collective drops, current spikes, voltage sags, rotor dips 21 rpm, and you can watch the governor's own I-term hold it.

Tests: 57 total, all green (5 new for the window/event/cause helpers). UI smoke green.

Merging: just the button, no conflicts with anything open. If you'd like this in v0.3.5, merge this one **before** #14, then tag — I've updated #14's changelog to cover it either way.
