### PR TITLE
PID & Filter Labs: per-headspeed-profile breakdowns

### DIFF
--- a/src/analysis/evidenceViews.js
+++ b/src/analysis/evidenceViews.js
@@ -250,6 +250,36 @@ export function explainLoadEvent({
   };
 }
 
+// Longest run of consecutive integers in an ascending index
+// list — the FFT needs continuous samples, so a bank's stable
+// time only counts where it is unbroken.
+export function longestConsecutiveRun(indexes) {
+  if (!Array.isArray(indexes) || indexes.length === 0) {
+    return null;
+  }
+
+  let bestStart = indexes[0];
+  let bestLength = 1;
+  let runStart = indexes[0];
+  let runLength = 1;
+
+  for (let i = 1; i < indexes.length; i += 1) {
+    if (indexes[i] === indexes[i - 1] + 1) {
+      runLength += 1;
+    } else {
+      runStart = indexes[i];
+      runLength = 1;
+    }
+
+    if (runLength > bestLength) {
+      bestLength = runLength;
+      bestStart = runStart;
+    }
+  }
+
+  return { startIndex: bestStart, length: bestLength };
+}
+
 // Group stable-flight samples by governor target so
 // averages can be reported per headspeed profile (bank).
 // Targets within one percent of each other belong to the

--- a/src/analysis/profilePidBreakdown.js
+++ b/src/analysis/profilePidBreakdown.js
@@ -1,0 +1,130 @@
+// ======================================================
+// BLACKBOX LAB — PER-PROFILE RESPONSE BREAKDOWN
+// ======================================================
+//
+// Helicopters behave differently at different headspeeds.
+// This module measures, per headspeed profile and axis, how
+// often the response overshot what was asked: the share of
+// commanded samples where the filtered gyro exceeded the
+// setpoint beyond a deadband, and the largest such
+// exceedance. It samples rows exactly the way the PID
+// analysis does, so profiles and values line up. Evidence
+// only — no score reads this.
+//
+// ======================================================
+
+import { getColumnValuesByRowIndexes } from "./mathHelpers.js";
+
+const COMMAND_THRESHOLD = 30; // deg/s — below this it's noise
+const EXCEEDANCE_DEADBAND = 10; // deg/s beyond the setpoint
+
+export function analyzeProfileResponse({
+  lines,
+  telemetryHeaderIndex,
+  headspeedProfiles,
+  setpointColumns,
+  gyroColumns,
+  axisNames = ["Roll", "Pitch", "Yaw"]
+}) {
+  if (
+    !Array.isArray(lines) ||
+    !Number.isInteger(telemetryHeaderIndex) ||
+    telemetryHeaderIndex < 0 ||
+    !Array.isArray(headspeedProfiles) ||
+    !Array.isArray(setpointColumns) ||
+    !Array.isArray(gyroColumns)
+  ) {
+    return [];
+  }
+
+  return headspeedProfiles.map((profile) => {
+    const rowIndexes = Array.isArray(profile.sampleIndexes)
+      ? profile.sampleIndexes
+      : [];
+
+    const axisResults = axisNames.map((axis, axisIndex) => {
+      const setpointColumn = setpointColumns[axisIndex];
+      const gyroColumn = gyroColumns[axisIndex];
+
+      if (!setpointColumn || !gyroColumn) {
+        return {
+          axis,
+          commandedSampleCount: 0,
+          exceedanceRatePercent: null,
+          peakExceedancePercent: null
+        };
+      }
+
+      const setpointValues = getColumnValuesByRowIndexes(
+        lines,
+        telemetryHeaderIndex,
+        setpointColumn,
+        rowIndexes
+      );
+
+      const gyroValues = getColumnValuesByRowIndexes(
+        lines,
+        telemetryHeaderIndex,
+        gyroColumn,
+        rowIndexes
+      );
+
+      const sampleCount = Math.min(
+        setpointValues.length,
+        gyroValues.length
+      );
+
+      let commandedSampleCount = 0;
+      let exceededSampleCount = 0;
+      let peakExceedancePercent = null;
+
+      for (let i = 0; i < sampleCount; i += 1) {
+        const setpoint = setpointValues[i];
+        const gyro = gyroValues[i];
+
+        if (
+          !Number.isFinite(setpoint) ||
+          !Number.isFinite(gyro) ||
+          Math.abs(setpoint) < COMMAND_THRESHOLD
+        ) {
+          continue;
+        }
+
+        commandedSampleCount += 1;
+
+        const exceedance =
+          Math.abs(gyro) -
+          (Math.abs(setpoint) + EXCEEDANCE_DEADBAND);
+
+        if (exceedance > 0) {
+          exceededSampleCount += 1;
+
+          const exceedancePercent =
+            (exceedance / Math.abs(setpoint)) * 100;
+
+          if (
+            peakExceedancePercent === null ||
+            exceedancePercent > peakExceedancePercent
+          ) {
+            peakExceedancePercent = exceedancePercent;
+          }
+        }
+      }
+
+      return {
+        axis,
+        commandedSampleCount,
+        exceedanceRatePercent:
+          commandedSampleCount > 0
+            ? (exceededSampleCount / commandedSampleCount) * 100
+            : null,
+        peakExceedancePercent
+      };
+    });
+
+    return {
+      targetRpm: profile.targetRpm,
+      axisResults
+    };
+  });
+}

--- a/src/index.html
+++ b/src/index.html
@@ -409,6 +409,17 @@
           <div id="filterAdvisorRecommendations"></div>
         </section>
 
+        <section class="card" id="filterProfileCard" hidden>
+          <h3>Noise By Headspeed Profile</h3>
+          <p class="chart-hint">
+            Rotor harmonics move with rpm — a filter setup that is
+            clean in one bank can sit right on a peak in another.
+            Each bank below gets its own spectrum from its own
+            stable flight time, and its own advice.
+          </p>
+          <div id="filterProfileBlocks"></div>
+        </section>
+
         <section class="card" id="filterLabSection">
           <details class="drilldown">
           <summary>Technical filter analysis — for when you want the numbers</summary>
@@ -447,6 +458,19 @@
         <section class="hero">
           <h2>PID Lab</h2>
           <p>How faithfully your helicopter follows your hands.</p>
+        </section>
+
+        <section class="card" id="pidProfileCard" hidden>
+          <h3>Tracking By Headspeed Profile</h3>
+          <p class="chart-hint">
+            Helicopters behave differently at different headspeeds.
+            Per bank: how closely each axis followed the target, and
+            how often the response overshot what was asked.
+          </p>
+          <div class="table-scroll">
+            <table class="history-table" id="pidProfileTable"></table>
+          </div>
+          <p class="chart-hint" id="pidProfileNote"></p>
         </section>
 
         <section class="card" id="pidLabSection">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -50,8 +50,10 @@ import {
   windowStats,
   findHighestLoadEvents,
   explainLoadEvent,
-  groupByGovernorTarget
+  groupByGovernorTarget,
+  longestConsecutiveRun
 } from "./analysis/evidenceViews.js";
+import { analyzeProfileResponse } from "./analysis/profilePidBreakdown.js";
 import { analyzeEscLab } from "./analysis/escLabAnalysis.js";
 import { analyzeBatteryLab } from "./analysis/batteryLabAnalysis.js";
 //
@@ -154,6 +156,12 @@ const filterAdvisorCard = el("filterAdvisorCard");
 const filterAdvisorStory = el("filterAdvisorStory");
 const filterAdvisorTable = el("filterAdvisorTable");
 const filterAdvisorRecommendations = el("filterAdvisorRecommendations");
+
+const filterProfileCard = el("filterProfileCard");
+const filterProfileBlocks = el("filterProfileBlocks");
+const pidProfileCard = el("pidProfileCard");
+const pidProfileTable = el("pidProfileTable");
+const pidProfileNote = el("pidProfileNote");
 
 const compareBaselineInfo = el("compareBaselineInfo");
 const compareOpenButton = el("compareOpenButton");
@@ -760,6 +768,130 @@ if (
     headspeedRpm: governedHeadspeed
   });
 
+  // ---- filter behavior per headspeed bank ----
+  // Rotor harmonics move with rpm, so each bank gets its own
+  // spectrum and its own advice — computed only from that
+  // bank's longest unbroken stable stretch. Evidence only.
+  const perBankFilter = (() => {
+    const banks = groupByGovernorTarget({
+      governorTarget: alignedGovernorTarget,
+      sampleIndexes: spectrumFlightPhase.stableIndexes ?? []
+    });
+
+    if (banks.length < 2 || !sampleRate) {
+      return [];
+    }
+
+    let strongestAxisIndex = 0;
+    let strongestPeak = 0;
+
+    spectra.forEach((entry, index) => {
+      for (const value of entry.spectrum.magnitudes) {
+        if (value > strongestPeak) {
+          strongestPeak = value;
+          strongestAxisIndex = index;
+        }
+      }
+    });
+
+    const unfilteredName =
+      gyroColumnNames[strongestAxisIndex] ?? gyroColumnNames[0];
+    const filteredName =
+      filteredColumns[strongestAxisIndex] ?? filteredColumns[0];
+
+    const bankWindowSamples = (columnName, startIndex) => {
+      if (!columnName) {
+        return [];
+      }
+
+      const values = alignedColumnValues(columnName).slice(
+        startIndex,
+        startIndex + fftWindowSize
+      );
+
+      return values.length === fftWindowSize &&
+        values.every(Number.isFinite)
+        ? values
+        : [];
+    };
+
+    return banks.map((bank) => {
+      const run = longestConsecutiveRun(bank.indexes);
+
+      if (!run || run.length < fftWindowSize) {
+        return {
+          targetRpm: bank.targetRpm,
+          stableSampleCount: bank.indexes.length,
+          insufficient: true
+        };
+      }
+
+      const windowStart =
+        run.startIndex +
+        Math.floor((run.length - fftWindowSize) / 2);
+
+      const unfilteredSpectrum = computeNoiseSpectrum(
+        bankWindowSamples(unfilteredName, windowStart),
+        sampleRate,
+        { segmentSize: fftWindowSize }
+      );
+
+      if (!unfilteredSpectrum) {
+        return {
+          targetRpm: bank.targetRpm,
+          stableSampleCount: bank.indexes.length,
+          insufficient: true
+        };
+      }
+
+      const filteredSpectrum = hasOwnUnfiltered(headerLine)
+        ? computeNoiseSpectrum(
+            bankWindowSamples(filteredName, windowStart),
+            sampleRate,
+            { segmentSize: fftWindowSize }
+          )
+        : null;
+
+      const bankHeadspeed = windowStats(
+        alignedHeadspeed,
+        windowStart,
+        windowStart + fftWindowSize - 1
+      );
+
+      const bankRpm = bankHeadspeed
+        ? bankHeadspeed.average
+        : bank.targetRpm;
+
+      return {
+        targetRpm: bank.targetRpm,
+        actualRpm: Math.round(bankRpm),
+        stableSampleCount: bank.indexes.length,
+        insufficient: false,
+        spectra: [
+          {
+            label: `${unfilteredName} (raw)`,
+            spectrum: unfilteredSpectrum,
+            color: CHART_COLORS[1]
+          },
+          ...(filteredSpectrum
+            ? [
+                {
+                  label: `${filteredName} (filtered)`,
+                  spectrum: filteredSpectrum,
+                  color: CHART_COLORS[0]
+                }
+              ]
+            : [])
+        ],
+        advice: adviseFilters({
+          unfilteredSpectrum,
+          filteredSpectrum,
+          headspeedRpm: bankRpm
+        })
+      };
+    });
+  })();
+
   // ---- labs + verdict ----
   const labs = {
     governor: analyzeGovernorLab({ timeSeconds, headspeed, governorTarget }),
@@ -832,6 +964,7 @@ if (
     amperage,
     spectra,
     markers,
+    perBankFilter,
     labs,
     verdict
   };
@@ -1653,6 +1786,8 @@ function renderAllCharts(dataset) {
     droopContextCard.hidden = true;
     loadEventsCard.hidden = true;
     escProfileCard.hidden = true;
+    pidProfileCard.hidden = true;
+    filterProfileCard.hidden = true;
 
     return;
   }
@@ -1842,6 +1977,178 @@ function renderFilterAdvisor(dataset) {
   });
 }
 
+// ---- per-headspeed-profile breakdowns (PID & Filter Labs) ----
+// Evidence only: the headline results and all scoring stay
+// exactly as they are; these cards break the same flight down
+// by governor bank.
+
+function renderPidProfileBreakdown(pidAnalysis, lines) {
+  const trackingProfiles =
+    pidAnalysis?.detectedColumns?.trackingAnalysis
+      ?.profileTrackingAnalysis ?? [];
+
+  const usableProfiles = trackingProfiles.filter((profile) =>
+    Number.isFinite(profile.averageTrackingError)
+  );
+
+  if (usableProfiles.length < 2) {
+    pidProfileCard.hidden = true;
+    return;
+  }
+
+  const analysisContext = pidAnalysis.analysisContext ?? {};
+
+  // The adapter's header line may quote column names — accept
+  // both, like the PID analysis itself does.
+  const gyroColumns = (analysisContext.telemetry?.allColumns ?? [])
+    .filter((name) =>
+      /^"?gyroADC\[[0-2]\]"?$/i.test(String(name).trim())
+    )
+    .sort();
+
+  const responseProfiles = analyzeProfileResponse({
+    lines,
+    telemetryHeaderIndex:
+      analysisContext.flight?.telemetryHeaderIndex,
+    headspeedProfiles:
+      analysisContext.flight?.headspeedProfiles ?? [],
+    setpointColumns:
+      pidAnalysis.detectedColumns?.axisSetpoint ?? [],
+    gyroColumns
+  });
+
+  const responseByRpm = new Map(
+    responseProfiles.map((profile) => [profile.targetRpm, profile])
+  );
+
+  const numberCell = (value, digits = 1, suffix = "") =>
+    Number.isFinite(value) ? `${value.toFixed(digits)}${suffix}` : "—";
+
+  pidProfileCard.hidden = false;
+  pidProfileTable.innerHTML = `
+    <tr>
+      <th>Bank</th><th>Axis</th><th>Avg tracking error</th>
+      <th>Overshoot rate</th><th>Peak overshoot</th>
+    </tr>
+    ${usableProfiles
+      .map((profile) => {
+        const response = responseByRpm.get(profile.targetRpm);
+
+        return (profile.axisResults ?? [])
+          .map((axisResult, axisIndex) => {
+            const axisResponse = response?.axisResults?.find(
+              (candidate) => candidate.axis === axisResult.axis
+            );
+
+            return `
+        <tr>
+          <td>${axisIndex === 0 ? `${profile.targetRpm} rpm` : ""}</td>
+          <td>${axisResult.axis}</td>
+          <td>${numberCell(axisResult.averageAbsoluteError, 2)}</td>
+          <td>${numberCell(axisResponse?.exceedanceRatePercent, 1, "%")}</td>
+          <td>${numberCell(axisResponse?.peakExceedancePercent, 0, "%")}</td>
+        </tr>`;
+          })
+          .join("");
+      })
+      .join("")}
+  `;
+
+  const best = usableProfiles.reduce((a, b) =>
+    a.averageTrackingError <= b.averageTrackingError ? a : b
+  );
+  const worst = usableProfiles.reduce((a, b) =>
+    a.averageTrackingError >= b.averageTrackingError ? a : b
+  );
+
+  pidProfileNote.textContent =
+    best.targetRpm === worst.targetRpm
+      ? ""
+      : `${best.targetRpm} rpm tracked best overall; ${worst.targetRpm} rpm tracked worst. Overshoot rate = share of commanded samples where the response exceeded the target beyond a small deadband.`;
+}
+
+function renderFilterProfileBreakdown(dataset) {
+  const banks = dataset?.perBankFilter ?? [];
+
+  if (banks.length < 2) {
+    filterProfileCard.hidden = true;
+    return;
+  }
+
+  filterProfileCard.hidden = false;
+  filterProfileBlocks.innerHTML = "";
+
+  for (const bank of banks) {
+    const heading = document.createElement("h4");
+    heading.textContent = bank.insufficient
+      ? `${bank.targetRpm} rpm bank`
+      : `${bank.targetRpm} rpm bank (flown at ~${bank.actualRpm} rpm)`;
+    filterProfileBlocks.appendChild(heading);
+
+    if (bank.insufficient) {
+      const note = document.createElement("p");
+      note.className = "chart-hint";
+      note.textContent =
+        "Not enough continuous stable time at this headspeed for a spectrum — fly a longer steady stretch in this bank to analyze it.";
+      filterProfileBlocks.appendChild(note);
+      continue;
+    }
+
+    const chartElement = document.createElement("div");
+    chartElement.className = "chart-container";
+    filterProfileBlocks.appendChild(chartElement);
+
+    renderSpectrumChart(chartElement, bank.spectra, {
+      height: 220,
+      markers: buildSpectrumMarkers(bank.spectra, bank.actualRpm)
+    });
+
+    const advice = bank.advice;
+
+    if (advice && advice.rows.length > 0) {
+      const table = document.createElement("table");
+      table.className = "history-table";
+      table.innerHTML = `
+        <tr>
+          <th>Peak</th><th>Likely source</th>
+          <th>Peak reduction</th>
+        </tr>
+        ${advice.rows
+          .map(
+            (row) => `
+          <tr>
+            <td>${row.hz} Hz</td>
+            <td>${row.source}</td>
+            <td>${
+              row.reductionPercent !== null
+                ? row.reductionPercent + "%"
+                : "—"
+            }</td>
+          </tr>`
+          )
+          .join("")}
+      `;
+
+      const scroll = document.createElement("div");
+      scroll.className = "table-scroll";
+      scroll.appendChild(table);
+      filterProfileBlocks.appendChild(scroll);
+    }
+
+    for (const recommendation of advice?.recommendations ?? []) {
+      if (recommendation.priority !== "filters") {
+        continue;
+      }
+
+      const item = document.createElement("div");
+      item.className =
+        "advisor-recommendation priority-filters";
+      item.innerHTML = `<span>Filters:</span> ${recommendation.text}`;
+      filterProfileBlocks.appendChild(item);
+    }
+  }
+}
+
 // ======================================================
 // 06. ANALYSIS + SCREEN UPDATE
 // ======================================================
@@ -1902,6 +2209,8 @@ function analyzeFlight(flightIndex) {
   renderQuality(currentDataset, flight.stats);
   renderFilterAdvisor(currentDataset);
   renderAllCharts(currentDataset);
+  renderPidProfileBreakdown(pidAnalysis, lines);
+  renderFilterProfileBreakdown(currentDataset);
 
   renderLab(
     currentDataset?.labs.governor,

--- a/test/profileBreakdown.test.mjs
+++ b/test/profileBreakdown.test.mjs
@@ -1,0 +1,96 @@
+// ======================================================
+// BLACKBOX LAB — PER-PROFILE BREAKDOWN TESTS
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { longestConsecutiveRun } from "../src/analysis/evidenceViews.js";
+import { analyzeProfileResponse } from "../src/analysis/profilePidBreakdown.js";
+
+test("longestConsecutiveRun finds the biggest unbroken stretch", () => {
+  assert.deepEqual(
+    longestConsecutiveRun([1, 2, 3, 10, 11, 12, 13, 14, 30]),
+    { startIndex: 10, length: 5 }
+  );
+  assert.deepEqual(longestConsecutiveRun([7]), {
+    startIndex: 7,
+    length: 1
+  });
+  assert.equal(longestConsecutiveRun([]), null);
+});
+
+// A tiny synthetic CSV: header + rows. Bank A rows track
+// cleanly; bank B rows overshoot the setpoint by 50%.
+function syntheticLines() {
+  const lines = ['time,setpoint[0],gyroADC[0]'];
+
+  for (let i = 0; i < 60; i += 1) {
+    lines.push(`${i},100,102`); // bank A: tight tracking
+  }
+
+  for (let i = 60; i < 120; i += 1) {
+    lines.push(`${i},100,150`); // bank B: 50% overshoot
+  }
+
+  return lines;
+}
+
+test("analyzeProfileResponse measures overshoot per profile", () => {
+  const lines = syntheticLines();
+
+  const profiles = [
+    {
+      targetRpm: 1700,
+      // row indexes are relative to the header line
+      sampleIndexes: Array.from({ length: 60 }, (_, i) => i + 1)
+    },
+    {
+      targetRpm: 1900,
+      sampleIndexes: Array.from({ length: 60 }, (_, i) => i + 61)
+    }
+  ];
+
+  const results = analyzeProfileResponse({
+    lines,
+    telemetryHeaderIndex: 0,
+    headspeedProfiles: profiles,
+    setpointColumns: ["setpoint[0]"],
+    gyroColumns: ["gyroADC[0]"],
+    axisNames: ["Roll"]
+  });
+
+  assert.equal(results.length, 2);
+
+  const calm = results[0].axisResults[0];
+  assert.equal(calm.axis, "Roll");
+  assert.ok(calm.commandedSampleCount > 0);
+  assert.equal(calm.exceedanceRatePercent, 0);
+  assert.equal(calm.peakExceedancePercent, null);
+
+  const hot = results[1].axisResults[0];
+  assert.equal(hot.exceedanceRatePercent, 100);
+  assert.ok(
+    hot.peakExceedancePercent > 30 &&
+      hot.peakExceedancePercent < 50,
+    `peak exceedance should be ~40% (150 vs 100+10 deadband), got ${hot.peakExceedancePercent}`
+  );
+});
+
+test("analyzeProfileResponse handles missing columns honestly", () => {
+  const results = analyzeProfileResponse({
+    lines: syntheticLines(),
+    telemetryHeaderIndex: 0,
+    headspeedProfiles: [
+      { targetRpm: 1700, sampleIndexes: [1, 2, 3] }
+    ],
+    setpointColumns: [],
+    gyroColumns: [],
+    axisNames: ["Roll"]
+  });
+
+  assert.equal(
+    results[0].axisResults[0].exceedanceRatePercent,
+    null
+  );
+});


### PR DESCRIPTION
Your idea from this morning, built: the per-headspeed-profile approach from Governor Lab, extended to PID Lab and Filter Lab. Same doctrine as before — **evidence views only, headline results and all scoring untouched.** Both new cards appear only when a flight actually visits two or more banks.

## PID Lab — "Tracking By Headspeed Profile"

Your analysis was already computing per-bank per-axis tracking error internally (it powers the "X RPM tracked best" sentence) — this card finally puts that table on screen. Added next to it: a per-bank overshoot measure — the share of commanded samples where the filtered gyro exceeded the setpoint beyond a small deadband, and the largest such exceedance. It samples rows through the same helpers your PID analysis uses, so the profiles line up exactly.

## Filter Lab — "Noise By Headspeed Profile"

The reason the 3D crowd will care: rotor harmonics move with rpm, so a filter setup that's clean in one bank can sit right on a peak in another — and the combined spectrum averages that away. Each bank now gets:

- its own spectrum, computed only from that bank's longest **unbroken** stable stretch (raw + filtered overlaid),
- harmonic markers and Filter Advisor peak classification at that bank's **actual flown rpm**,
- its own filter recommendations.

A bank without enough continuous stable time says so honestly instead of showing a smeared spectrum.

## Validated on the real 3-bank flight

- The physics shows up exactly as predicted: the main-rotor 1/rev sits at 28.5 Hz in the 1710 bank and 29.5 Hz at 1770; the motor/bearing cluster moves 318 → 329 Hz.
- The PID card immediately earned its keep: roll/pitch/yaw track cleanly in every bank *except* yaw in the 1830 bank, which shows a 10.3% overshoot rate — a pattern the flight-wide view averaged away.
- 1770 rpm tracked best overall, 1710 worst — per-bank truth the combined score can't express.

Tests: 60 total, all green (3 new). UI smoke green.

Merging: just the button. If you want this in v0.3.5 too, merge this **before** #14 and then tag — I've updated #14's changelog to cover it either way.
