### PR TITLE
v0.3.5 batch: merge this one PR, then tag — bundles #14 #15 #17 #18 in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
   ESC temperature telemetry is read for the first time.
 - Charts in these views share their zoom — drag on one and the
   others follow. All scoring is untouched: evidence only.
+- **PID Lab: "Tracking By Headspeed Profile"** — per-bank,
+  per-axis tracking error plus an overshoot measure, because
+  helicopters behave differently at different headspeeds.
+- **Filter Lab: "Noise By Headspeed Profile"** — one spectrum
+  per governor bank from that bank's own stable flight time,
+  with peak classification and filter advice at that bank's
+  actual rpm. Rotor harmonics move with headspeed; the combined
+  spectrum can average away a peak that only one bank sees.
+  Both per-profile cards appear when a flight visits two or
+  more banks; scoring is untouched.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@
   spectrum can average away a peak that only one bank sees.
   Both per-profile cards appear when a flight visits two or
   more banks; scoring is untouched.
+- **ESC load events understand collective**: the synchronized
+  event view now includes the collective trace, and when an
+  event's collective demand nears the flight's own maximum the
+  reading becomes "Collective load" — the sag was a response to
+  the load, not necessarily evidence of a weak pack.
+- The sidebar now shows the app version.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## v0.3.5 — the tuning charts release
+
+### Added
+
+- **Per-axis tuning preset charts** (from Ben Britton's feedback):
+  the Log Viewer's single roll-only Setpoint-vs-Gyro chart is now
+  three cards — Roll, Pitch and Yaw Tuning — each with three
+  ready-made presets: Tracking (target + gyro), Feedforward check
+  (+ I-term: I near zero while tracking = FF carrying the
+  maneuver, as Rotorflight intends) and Term balance
+  (target + P/I/D). Beginner mode shows Tracking only; Advanced
+  mode lays everything out. Colors mean the same thing on every
+  chart: blue target, orange gyro, green I, amber P, magenta D.
+- **Remove individual flights from the Health Record**: every row
+  in the Logged Flights table has a ✕ button — one bad log no
+  longer means wiping the whole record. Trends recompute without
+  the removed flight; Clear all history stays for the full wipe.
+- The HTML report now includes the tracking chart for all three
+  axes (was roll only).
+
+### Fixed
+
+- The UI smoke test now asserts that all nine preset charts
+  render with scaled data.
+
 ## v0.3.4 — feedforward doctrine + release repair
 
 Builds directly on v0.3.3's scoring cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@
   the removed flight; Clear all history stays for the full wipe.
 - The HTML report now includes the tracking chart for all three
   axes (was roll only).
+- **Governor Lab: "The Worst Droop, In Context"** — the seconds
+  around the biggest dip on one linked clock: target/actual RPM
+  and error, motor output + collective, voltage + current, and
+  the log's own recorded governor P/I/D/F/Sum terms (shown only
+  when genuinely present, never estimated from throttle).
+- **ESC Lab: "Highest-Load Moments"** — the hardest-working
+  seconds with a plain-language cause each (at the limit /
+  battery sag / normal load), a synchronized view of output,
+  current + voltage, power and ESC temperature around the
+  biggest event, and stable-flight averages per governor bank.
+  ESC temperature telemetry is read for the first time.
+- Charts in these views share their zoom — drag on one and the
+  others follow. All scoring is untouched: evidence only.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Blackbox Lab is an open-source desktop application designed to make Rotorflight 
 
 ---
 
+## Download
+
+Ready-made installers for **Windows, macOS and Linux** are on the
+[Releases page](https://github.com/hillbilly1975/Blackbox_Lab/releases/latest)
+— download, install, open a log. No build tools needed.
+
+---
+
 ## What It Looks Like
 
 **Open a log — get answers, not data.** Every flight lands on a
@@ -34,18 +42,60 @@ Blackbox Lab explains what happened during the flight using plain English and pr
 
 ---
 
-## Planned Features
+## Working Today
 
-- Automatic Blackbox Analysis
-- Governor Performance Reports
-- PID Health Reports
+- **Native .bbl decoding** — open raw Blackbox files straight off
+  the flight controller, no CSV conversion. Multi-flight files
+  supported, corrupt bytes skipped gracefully.
+- **Flight Verdict** — answers first: plain-language cards with
+  status, cause, what to do, and a jump straight to the evidence.
+- **Log Quality Gate** — before analysis, the app tells you what
+  this log can and cannot answer, and which logging settings to
+  enable for more.
+- **Charts, all laid out** — gyro, headspeed & governor, throttle,
+  battery & current, and per-axis tuning presets for Roll, Pitch
+  and Yaw: tracking, feedforward check and term balance. Drag to
+  zoom; live min/max readouts follow the zoom window.
+- **Noise spectrum** — built-in FFT shows vibration by frequency
+  in the Filter Lab.
+- **Filter Advisor** — peaks classified against rotor harmonics,
+  filter attenuation measured unfiltered-vs-filtered, with
+  concrete RPM-filter recommendations — mechanics first.
+- **PID & Filter analysis** — scores, findings, confidence and
+  recommendations in plain language. Missing telemetry gives an
+  honest "could not be measured", never a fake score.
+- **Governor, ESC & Battery Labs** — droop analysis, throttle
+  headroom & saturation, voltage sag, estimated pack internal
+  resistance and consumed capacity.
+- **Compare Flights** — before vs after: "your change made the
+  biggest vibration peak 86% better."
+- **Health Record** — every analyzed flight is filed per craft
+  (locally); rising vibration or droop across flights triggers a
+  warning before something breaks. Individual flights can be
+  removed from the record.
+- **One-file reports** — verdict, findings and charts in a single
+  shareable HTML file.
+- **Beginner & Advanced modes** — calm by default, everything
+  laid out when you switch.
+- **Update check** — a quiet banner when a newer release exists.
+- **Community log sharing** — strictly opt-in and anonymized:
+  contributed logs help make the analysis smarter for everyone.
+  Off until you say yes; details in
+  [Documentation/CONTRIBUTED-DATA.md](Documentation/CONTRIBUTED-DATA.md).
+- **Sample flights** — three ready-made logs in `samples/` (with
+  documented ground truth) so you can explore without a log at
+  hand ("Try a Sample Flight" — one click). These are recordings
+  for the app — not firmware, nothing is ever written to a
+  helicopter.
+
+## On the Roadmap
+
 - Servo Activity Reports
-- ESC Performance Reports
-- Battery Performance Reports
 - Flight Playback
 - Rotorflight Configuration Review
-- Beginner & Advanced Modes
-- One-click Report Generation
+
+The longer list of ideas lives in
+[Documentation/BLACKBOX_LAB_ROADMAP.md](Documentation/BLACKBOX_LAB_ROADMAP.md).
 
 ---
 
@@ -57,36 +107,7 @@ Deeper when you want it.
 
 ---
 
-## Working Today (v0.2)
-
-- **Native .bbl decoding** — open raw Blackbox files straight off
-  the flight controller, no CSV conversion. Multi-flight files
-  supported, corrupt bytes skipped gracefully.
-- **Charts** — gyro, setpoint-vs-gyro tracking, headspeed &
-  governor, motor & power. Drag to zoom.
-- **Noise spectrum** — built-in FFT shows vibration by frequency
-  in the Filter Lab.
-- **Filter & PID analysis** — scores, findings, confidence and
-  recommendations in plain language.
-- **Flight Verdict** — answers first: plain-language cards with
-  status, cause, what to do, and a jump straight to the evidence.
-- **Governor, ESC & Battery Labs** — droop analysis, throttle
-  headroom & saturation, voltage sag, estimated pack internal
-  resistance and consumed capacity.
-- **Compare Flights** — before vs after: "your change made the
-  biggest vibration peak 86% better."
-- **Health Record** — every analyzed flight is filed per craft
-  (locally); rising vibration or droop across flights triggers a
-  warning before something breaks.
-- **One-file reports** — verdict, findings and charts in a single
-  shareable HTML file.
-- **Sample flights** — three ready-made logs in `samples/` (with
-  documented ground truth) so you can explore without a log at
-  hand ("Try a Sample Flight" — one click). These are recordings
-  for the app — not firmware, nothing is ever written to a
-  helicopter.
-
-## Quick Start
+## Running From Source (developers)
 
 ```
 npm install

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blackbox-lab",
   "productName": "Blackbox Lab",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Rotorflight Blackbox analysis suite \u2014 simple first, deeper when you want it.",
   "main": "src/index.js",
   "private": true,

--- a/src/analysis/evidenceViews.js
+++ b/src/analysis/evidenceViews.js
@@ -208,15 +208,37 @@ export function findHighestLoadEvents(
   );
 }
 
-// Why was the output high here? Three answers a pilot can
-// act on, in priority order: the ESC genuinely ran out of
-// headroom; the battery sagged so more throttle was needed
-// for the same power; or it was simply a demanding moment
-// working as designed.
+// Did the collective drive this event? True when the event's
+// peak collective demand approaches the flight's own maximum
+// AND clearly exceeds the flight's typical level — the second
+// guard keeps a steady hover (where every moment is near the
+// tiny "maximum") from reading as a pitch pump.
+export function isCollectiveDriven({
+  eventPeakCollective,
+  flightPeakCollective,
+  flightMedianCollective
+}) {
+  return (
+    Number.isFinite(eventPeakCollective) &&
+    Number.isFinite(flightPeakCollective) &&
+    Number.isFinite(flightMedianCollective) &&
+    flightPeakCollective > 0 &&
+    eventPeakCollective >= flightPeakCollective * 0.7 &&
+    eventPeakCollective >= flightMedianCollective * 1.5
+  );
+}
+
+// Why was the output high here? Answers a pilot can act on,
+// in priority order: the ESC genuinely ran out of headroom;
+// the collective demanded it (a pitch pump — the load is the
+// pilot's doing, wording per Daniel); the battery sagged so
+// more throttle was needed for the same power; or it was
+// simply a demanding moment working as designed.
 export function explainLoadEvent({
   outputPeakPercent,
   outputSaturatedShare,
-  voltageSagPercent
+  voltageSagPercent,
+  collectiveDriven = false
 }) {
   const saturated =
     Number.isFinite(outputPeakPercent) &&
@@ -232,10 +254,20 @@ export function explainLoadEvent({
     };
   }
 
-  if (
+  const sagged =
     Number.isFinite(voltageSagPercent) &&
-    voltageSagPercent >= 8
-  ) {
+    voltageSagPercent >= 8;
+
+  if (collectiveDriven) {
+    return {
+      cause: "collective-load",
+      sentence: sagged
+        ? "Collective demand rose sharply at the same time as current, power and ESC output. This is consistent with a hard pitch pump or other demanding collective maneuver. The battery sag was a response to the load, not necessarily evidence of a weak pack."
+        : "Collective demand rose sharply at the same time as current, power and ESC output. This is consistent with a hard pitch pump or other demanding collective maneuver — the power system followed the demand with voltage holding up well."
+    };
+  }
+
+  if (sagged) {
     return {
       cause: "battery-sag",
       sentence:

--- a/src/analysis/evidenceViews.js
+++ b/src/analysis/evidenceViews.js
@@ -250,6 +250,36 @@ export function explainLoadEvent({
   };
 }
 
+// Longest run of consecutive integers in an ascending index
+// list — the FFT needs continuous samples, so a bank's stable
+// time only counts where it is unbroken.
+export function longestConsecutiveRun(indexes) {
+  if (!Array.isArray(indexes) || indexes.length === 0) {
+    return null;
+  }
+
+  let bestStart = indexes[0];
+  let bestLength = 1;
+  let runStart = indexes[0];
+  let runLength = 1;
+
+  for (let i = 1; i < indexes.length; i += 1) {
+    if (indexes[i] === indexes[i - 1] + 1) {
+      runLength += 1;
+    } else {
+      runStart = indexes[i];
+      runLength = 1;
+    }
+
+    if (runLength > bestLength) {
+      bestLength = runLength;
+      bestStart = runStart;
+    }
+  }
+
+  return { startIndex: bestStart, length: bestLength };
+}
+
 // Group stable-flight samples by governor target so
 // averages can be reported per headspeed profile (bank).
 // Targets within one percent of each other belong to the

--- a/src/analysis/profilePidBreakdown.js
+++ b/src/analysis/profilePidBreakdown.js
@@ -1,0 +1,130 @@
+// ======================================================
+// BLACKBOX LAB — PER-PROFILE RESPONSE BREAKDOWN
+// ======================================================
+//
+// Helicopters behave differently at different headspeeds.
+// This module measures, per headspeed profile and axis, how
+// often the response overshot what was asked: the share of
+// commanded samples where the filtered gyro exceeded the
+// setpoint beyond a deadband, and the largest such
+// exceedance. It samples rows exactly the way the PID
+// analysis does, so profiles and values line up. Evidence
+// only — no score reads this.
+//
+// ======================================================
+
+import { getColumnValuesByRowIndexes } from "./mathHelpers.js";
+
+const COMMAND_THRESHOLD = 30; // deg/s — below this it's noise
+const EXCEEDANCE_DEADBAND = 10; // deg/s beyond the setpoint
+
+export function analyzeProfileResponse({
+  lines,
+  telemetryHeaderIndex,
+  headspeedProfiles,
+  setpointColumns,
+  gyroColumns,
+  axisNames = ["Roll", "Pitch", "Yaw"]
+}) {
+  if (
+    !Array.isArray(lines) ||
+    !Number.isInteger(telemetryHeaderIndex) ||
+    telemetryHeaderIndex < 0 ||
+    !Array.isArray(headspeedProfiles) ||
+    !Array.isArray(setpointColumns) ||
+    !Array.isArray(gyroColumns)
+  ) {
+    return [];
+  }
+
+  return headspeedProfiles.map((profile) => {
+    const rowIndexes = Array.isArray(profile.sampleIndexes)
+      ? profile.sampleIndexes
+      : [];
+
+    const axisResults = axisNames.map((axis, axisIndex) => {
+      const setpointColumn = setpointColumns[axisIndex];
+      const gyroColumn = gyroColumns[axisIndex];
+
+      if (!setpointColumn || !gyroColumn) {
+        return {
+          axis,
+          commandedSampleCount: 0,
+          exceedanceRatePercent: null,
+          peakExceedancePercent: null
+        };
+      }
+
+      const setpointValues = getColumnValuesByRowIndexes(
+        lines,
+        telemetryHeaderIndex,
+        setpointColumn,
+        rowIndexes
+      );
+
+      const gyroValues = getColumnValuesByRowIndexes(
+        lines,
+        telemetryHeaderIndex,
+        gyroColumn,
+        rowIndexes
+      );
+
+      const sampleCount = Math.min(
+        setpointValues.length,
+        gyroValues.length
+      );
+
+      let commandedSampleCount = 0;
+      let exceededSampleCount = 0;
+      let peakExceedancePercent = null;
+
+      for (let i = 0; i < sampleCount; i += 1) {
+        const setpoint = setpointValues[i];
+        const gyro = gyroValues[i];
+
+        if (
+          !Number.isFinite(setpoint) ||
+          !Number.isFinite(gyro) ||
+          Math.abs(setpoint) < COMMAND_THRESHOLD
+        ) {
+          continue;
+        }
+
+        commandedSampleCount += 1;
+
+        const exceedance =
+          Math.abs(gyro) -
+          (Math.abs(setpoint) + EXCEEDANCE_DEADBAND);
+
+        if (exceedance > 0) {
+          exceededSampleCount += 1;
+
+          const exceedancePercent =
+            (exceedance / Math.abs(setpoint)) * 100;
+
+          if (
+            peakExceedancePercent === null ||
+            exceedancePercent > peakExceedancePercent
+          ) {
+            peakExceedancePercent = exceedancePercent;
+          }
+        }
+      }
+
+      return {
+        axis,
+        commandedSampleCount,
+        exceedanceRatePercent:
+          commandedSampleCount > 0
+            ? (exceededSampleCount / commandedSampleCount) * 100
+            : null,
+        peakExceedancePercent
+      };
+    });
+
+    return {
+      targetRpm: profile.targetRpm,
+      axisResults
+    };
+  });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,13 @@ body {
   margin-top: 3px;
 }
 
+.sidebar-version {
+  color: var(--ink-muted);
+  font-size: 11px;
+  margin-top: 8px;
+  opacity: 0.8;
+}
+
 .sidebar h1 {
   margin: 0;
   font-size: 24px;

--- a/src/index.html
+++ b/src/index.html
@@ -32,6 +32,7 @@
         <span class="credit-line">A passion project by</span>
         <span class="credit-name">Daniel Sink</span>
         <span class="credit-sub">free, for the Rotorflight community</span>
+        <span class="sidebar-version" id="sidebarVersion"></span>
       </div>
     </aside>
 
@@ -597,6 +598,8 @@
             others follow.
           </p>
           <div class="chart-container" id="chartLoadOutput">
+          </div>
+          <div class="chart-container" id="chartLoadCollective">
           </div>
           <div class="chart-container" id="chartLoadPower">
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -409,6 +409,17 @@
           <div id="filterAdvisorRecommendations"></div>
         </section>
 
+        <section class="card" id="filterProfileCard" hidden>
+          <h3>Noise By Headspeed Profile</h3>
+          <p class="chart-hint">
+            Rotor harmonics move with rpm — a filter setup that is
+            clean in one bank can sit right on a peak in another.
+            Each bank below gets its own spectrum from its own
+            stable flight time, and its own advice.
+          </p>
+          <div id="filterProfileBlocks"></div>
+        </section>
+
         <section class="card" id="filterLabSection">
           <details class="drilldown">
           <summary>Technical filter analysis — for when you want the numbers</summary>
@@ -447,6 +458,19 @@
         <section class="hero">
           <h2>PID Lab</h2>
           <p>How faithfully your helicopter follows your hands.</p>
+        </section>
+
+        <section class="card" id="pidProfileCard" hidden>
+          <h3>Tracking By Headspeed Profile</h3>
+          <p class="chart-hint">
+            Helicopters behave differently at different headspeeds.
+            Per bank: how closely each axis followed the target, and
+            how often the response overshot what was asked.
+          </p>
+          <div class="table-scroll">
+            <table class="history-table" id="pidProfileTable"></table>
+          </div>
+          <p class="chart-hint" id="pidProfileNote"></p>
         </section>
 
         <section class="card" id="pidLabSection">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -50,6 +50,7 @@ import {
   windowStats,
   findHighestLoadEvents,
   explainLoadEvent,
+  isCollectiveDriven,
   groupByGovernorTarget,
   longestConsecutiveRun
 } from "./analysis/evidenceViews.js";
@@ -139,6 +140,7 @@ const loadEventsCard = el("loadEventsCard");
 const escEventsTable = el("escEventsTable");
 const escEventsStories = el("escEventsStories");
 const chartLoadOutput = el("chartLoadOutput");
+const chartLoadCollective = el("chartLoadCollective");
 const chartLoadPower = el("chartLoadPower");
 const chartLoadWatts = el("chartLoadWatts");
 const chartLoadTemp = el("chartLoadTemp");
@@ -192,6 +194,9 @@ const advancedModeToggle = el("advancedModeToggle");
 // ======================================================
 
 const navigation = initNavigation();
+
+// One source of truth: the same constant the update check uses.
+el("sidebarVersion").textContent = `v${APP_VERSION}`;
 
 function applyAdvancedMode(enabled) {
   document.body.classList.toggle("advanced-mode", enabled);
@@ -1486,6 +1491,38 @@ function renderEscEvidence(dataset) {
       : null;
   });
 
+  // Collective demand lets the app prove a pitch-pump load
+  // instead of leaving the pilot to correlate charts by hand.
+  const collectiveColumn =
+    dataset.findColumnsIn([/^setpoint\[3\]$/i])[0] ?? null;
+
+  const collectiveAbs = collectiveColumn
+    ? dataset
+        .columnValues(collectiveColumn)
+        .map((value) =>
+          Number.isFinite(value) ? Math.abs(value) : null
+        )
+    : null;
+
+  const collectiveFlightStats = (() => {
+    if (!collectiveAbs) {
+      return null;
+    }
+
+    const sorted = collectiveAbs
+      .filter(Number.isFinite)
+      .sort((first, second) => first - second);
+
+    if (sorted.length === 0) {
+      return null;
+    }
+
+    return {
+      peak: sorted[sorted.length - 1],
+      median: sorted[Math.floor(sorted.length / 2)]
+    };
+  })();
+
   // An all-zero temperature column means the sensor isn't
   // fitted (e.g. no second ESC) — don't plot a dead line.
   const temperatureEntries = [
@@ -1553,11 +1590,26 @@ function renderEscEvidence(dataset) {
         event.endIndex
       );
 
+      const eventCollective =
+        collectiveAbs && collectiveFlightStats
+          ? windowStats(
+              collectiveAbs,
+              event.startIndex,
+              event.endIndex
+            )
+          : null;
+
       const explanation = explainLoadEvent({
         outputPeakPercent: output?.max ?? null,
         outputSaturatedShare:
           outputCount > 0 ? saturatedCount / outputCount : null,
-        voltageSagPercent: sagPercent
+        voltageSagPercent: sagPercent,
+        collectiveDriven: isCollectiveDriven({
+          eventPeakCollective: eventCollective?.max ?? null,
+          flightPeakCollective: collectiveFlightStats?.peak ?? null,
+          flightMedianCollective:
+            collectiveFlightStats?.median ?? null
+        })
       });
 
       return { event, output, voltage, sagPercent, watts, explanation };
@@ -1586,9 +1638,11 @@ function renderEscEvidence(dataset) {
           <td>${
             explanation.cause === "headroom-limit"
               ? "At the limit"
-              : explanation.cause === "battery-sag"
-                ? "Battery sag"
-                : "Normal load"
+              : explanation.cause === "collective-load"
+                ? "Collective load"
+                : explanation.cause === "battery-sag"
+                  ? "Battery sag"
+                  : "Normal load"
           }</td>
         </tr>`
         )
@@ -1637,6 +1691,24 @@ function renderEscEvidence(dataset) {
         ],
         { yLabel: "output (%)", markers, linkGroup: "loadSync" }
       );
+
+      if (collectiveColumn) {
+        renderSyncedChart(
+          chartLoadCollective,
+          dataset,
+          window,
+          [
+            {
+              patterns: [/^setpoint\[3\]$/i],
+              label: "Collective target",
+              color: CHART_COLORS[5]
+            }
+          ],
+          { yLabel: "collective", markers, linkGroup: "loadSync" }
+        );
+      } else {
+        chartLoadCollective.hidden = true;
+      }
 
       renderSyncedChart(
         chartLoadPower,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -50,8 +50,10 @@ import {
   windowStats,
   findHighestLoadEvents,
   explainLoadEvent,
-  groupByGovernorTarget
+  groupByGovernorTarget,
+  longestConsecutiveRun
 } from "./analysis/evidenceViews.js";
+import { analyzeProfileResponse } from "./analysis/profilePidBreakdown.js";
 import { analyzeEscLab } from "./analysis/escLabAnalysis.js";
 import { analyzeBatteryLab } from "./analysis/batteryLabAnalysis.js";
 //
@@ -154,6 +156,12 @@ const filterAdvisorCard = el("filterAdvisorCard");
 const filterAdvisorStory = el("filterAdvisorStory");
 const filterAdvisorTable = el("filterAdvisorTable");
 const filterAdvisorRecommendations = el("filterAdvisorRecommendations");
+
+const filterProfileCard = el("filterProfileCard");
+const filterProfileBlocks = el("filterProfileBlocks");
+const pidProfileCard = el("pidProfileCard");
+const pidProfileTable = el("pidProfileTable");
+const pidProfileNote = el("pidProfileNote");
 
 const compareBaselineInfo = el("compareBaselineInfo");
 const compareOpenButton = el("compareOpenButton");
@@ -760,6 +768,130 @@ if (
     headspeedRpm: governedHeadspeed
   });
 
+  // ---- filter behavior per headspeed bank ----
+  // Rotor harmonics move with rpm, so each bank gets its own
+  // spectrum and its own advice — computed only from that
+  // bank's longest unbroken stable stretch. Evidence only.
+  const perBankFilter = (() => {
+    const banks = groupByGovernorTarget({
+      governorTarget: alignedGovernorTarget,
+      sampleIndexes: spectrumFlightPhase.stableIndexes ?? []
+    });
+
+    if (banks.length < 2 || !sampleRate) {
+      return [];
+    }
+
+    let strongestAxisIndex = 0;
+    let strongestPeak = 0;
+
+    spectra.forEach((entry, index) => {
+      for (const value of entry.spectrum.magnitudes) {
+        if (value > strongestPeak) {
+          strongestPeak = value;
+          strongestAxisIndex = index;
+        }
+      }
+    });
+
+    const unfilteredName =
+      gyroColumnNames[strongestAxisIndex] ?? gyroColumnNames[0];
+    const filteredName =
+      filteredColumns[strongestAxisIndex] ?? filteredColumns[0];
+
+    const bankWindowSamples = (columnName, startIndex) => {
+      if (!columnName) {
+        return [];
+      }
+
+      const values = alignedColumnValues(columnName).slice(
+        startIndex,
+        startIndex + fftWindowSize
+      );
+
+      return values.length === fftWindowSize &&
+        values.every(Number.isFinite)
+        ? values
+        : [];
+    };
+
+    return banks.map((bank) => {
+      const run = longestConsecutiveRun(bank.indexes);
+
+      if (!run || run.length < fftWindowSize) {
+        return {
+          targetRpm: bank.targetRpm,
+          stableSampleCount: bank.indexes.length,
+          insufficient: true
+        };
+      }
+
+      const windowStart =
+        run.startIndex +
+        Math.floor((run.length - fftWindowSize) / 2);
+
+      const unfilteredSpectrum = computeNoiseSpectrum(
+        bankWindowSamples(unfilteredName, windowStart),
+        sampleRate,
+        { segmentSize: fftWindowSize }
+      );
+
+      if (!unfilteredSpectrum) {
+        return {
+          targetRpm: bank.targetRpm,
+          stableSampleCount: bank.indexes.length,
+          insufficient: true
+        };
+      }
+
+      const filteredSpectrum = hasOwnUnfiltered(headerLine)
+        ? computeNoiseSpectrum(
+            bankWindowSamples(filteredName, windowStart),
+            sampleRate,
+            { segmentSize: fftWindowSize }
+          )
+        : null;
+
+      const bankHeadspeed = windowStats(
+        alignedHeadspeed,
+        windowStart,
+        windowStart + fftWindowSize - 1
+      );
+
+      const bankRpm = bankHeadspeed
+        ? bankHeadspeed.average
+        : bank.targetRpm;
+
+      return {
+        targetRpm: bank.targetRpm,
+        actualRpm: Math.round(bankRpm),
+        stableSampleCount: bank.indexes.length,
+        insufficient: false,
+        spectra: [
+          {
+            label: `${unfilteredName} (raw)`,
+            spectrum: unfilteredSpectrum,
+            color: CHART_COLORS[1]
+          },
+          ...(filteredSpectrum
+            ? [
+                {
+                  label: `${filteredName} (filtered)`,
+                  spectrum: filteredSpectrum,
+                  color: CHART_COLORS[0]
+                }
+              ]
+            : [])
+        ],
+        advice: adviseFilters({
+          unfilteredSpectrum,
+          filteredSpectrum,
+          headspeedRpm: bankRpm
+        })
+      };
+    });
+  })();
+
   // ---- labs + verdict ----
   const labs = {
     governor: analyzeGovernorLab({ timeSeconds, headspeed, governorTarget }),
@@ -832,6 +964,7 @@ if (
     amperage,
     spectra,
     markers,
+    perBankFilter,
     labs,
     verdict
   };
@@ -1653,6 +1786,8 @@ function renderAllCharts(dataset) {
     droopContextCard.hidden = true;
     loadEventsCard.hidden = true;
     escProfileCard.hidden = true;
+    pidProfileCard.hidden = true;
+    filterProfileCard.hidden = true;
 
     return;
   }
@@ -1842,6 +1977,178 @@ function renderFilterAdvisor(dataset) {
   });
 }
 
+// ---- per-headspeed-profile breakdowns (PID & Filter Labs) ----
+// Evidence only: the headline results and all scoring stay
+// exactly as they are; these cards break the same flight down
+// by governor bank.
+
+function renderPidProfileBreakdown(pidAnalysis, lines) {
+  const trackingProfiles =
+    pidAnalysis?.detectedColumns?.trackingAnalysis
+      ?.profileTrackingAnalysis ?? [];
+
+  const usableProfiles = trackingProfiles.filter((profile) =>
+    Number.isFinite(profile.averageTrackingError)
+  );
+
+  if (usableProfiles.length < 2) {
+    pidProfileCard.hidden = true;
+    return;
+  }
+
+  const analysisContext = pidAnalysis.analysisContext ?? {};
+
+  // The adapter's header line may quote column names — accept
+  // both, like the PID analysis itself does.
+  const gyroColumns = (analysisContext.telemetry?.allColumns ?? [])
+    .filter((name) =>
+      /^"?gyroADC\[[0-2]\]"?$/i.test(String(name).trim())
+    )
+    .sort();
+
+  const responseProfiles = analyzeProfileResponse({
+    lines,
+    telemetryHeaderIndex:
+      analysisContext.flight?.telemetryHeaderIndex,
+    headspeedProfiles:
+      analysisContext.flight?.headspeedProfiles ?? [],
+    setpointColumns:
+      pidAnalysis.detectedColumns?.axisSetpoint ?? [],
+    gyroColumns
+  });
+
+  const responseByRpm = new Map(
+    responseProfiles.map((profile) => [profile.targetRpm, profile])
+  );
+
+  const numberCell = (value, digits = 1, suffix = "") =>
+    Number.isFinite(value) ? `${value.toFixed(digits)}${suffix}` : "—";
+
+  pidProfileCard.hidden = false;
+  pidProfileTable.innerHTML = `
+    <tr>
+      <th>Bank</th><th>Axis</th><th>Avg tracking error</th>
+      <th>Overshoot rate</th><th>Peak overshoot</th>
+    </tr>
+    ${usableProfiles
+      .map((profile) => {
+        const response = responseByRpm.get(profile.targetRpm);
+
+        return (profile.axisResults ?? [])
+          .map((axisResult, axisIndex) => {
+            const axisResponse = response?.axisResults?.find(
+              (candidate) => candidate.axis === axisResult.axis
+            );
+
+            return `
+        <tr>
+          <td>${axisIndex === 0 ? `${profile.targetRpm} rpm` : ""}</td>
+          <td>${axisResult.axis}</td>
+          <td>${numberCell(axisResult.averageAbsoluteError, 2)}</td>
+          <td>${numberCell(axisResponse?.exceedanceRatePercent, 1, "%")}</td>
+          <td>${numberCell(axisResponse?.peakExceedancePercent, 0, "%")}</td>
+        </tr>`;
+          })
+          .join("");
+      })
+      .join("")}
+  `;
+
+  const best = usableProfiles.reduce((a, b) =>
+    a.averageTrackingError <= b.averageTrackingError ? a : b
+  );
+  const worst = usableProfiles.reduce((a, b) =>
+    a.averageTrackingError >= b.averageTrackingError ? a : b
+  );
+
+  pidProfileNote.textContent =
+    best.targetRpm === worst.targetRpm
+      ? ""
+      : `${best.targetRpm} rpm tracked best overall; ${worst.targetRpm} rpm tracked worst. Overshoot rate = share of commanded samples where the response exceeded the target beyond a small deadband.`;
+}
+
+function renderFilterProfileBreakdown(dataset) {
+  const banks = dataset?.perBankFilter ?? [];
+
+  if (banks.length < 2) {
+    filterProfileCard.hidden = true;
+    return;
+  }
+
+  filterProfileCard.hidden = false;
+  filterProfileBlocks.innerHTML = "";
+
+  for (const bank of banks) {
+    const heading = document.createElement("h4");
+    heading.textContent = bank.insufficient
+      ? `${bank.targetRpm} rpm bank`
+      : `${bank.targetRpm} rpm bank (flown at ~${bank.actualRpm} rpm)`;
+    filterProfileBlocks.appendChild(heading);
+
+    if (bank.insufficient) {
+      const note = document.createElement("p");
+      note.className = "chart-hint";
+      note.textContent =
+        "Not enough continuous stable time at this headspeed for a spectrum — fly a longer steady stretch in this bank to analyze it.";
+      filterProfileBlocks.appendChild(note);
+      continue;
+    }
+
+    const chartElement = document.createElement("div");
+    chartElement.className = "chart-container";
+    filterProfileBlocks.appendChild(chartElement);
+
+    renderSpectrumChart(chartElement, bank.spectra, {
+      height: 220,
+      markers: buildSpectrumMarkers(bank.spectra, bank.actualRpm)
+    });
+
+    const advice = bank.advice;
+
+    if (advice && advice.rows.length > 0) {
+      const table = document.createElement("table");
+      table.className = "history-table";
+      table.innerHTML = `
+        <tr>
+          <th>Peak</th><th>Likely source</th>
+          <th>Peak reduction</th>
+        </tr>
+        ${advice.rows
+          .map(
+            (row) => `
+          <tr>
+            <td>${row.hz} Hz</td>
+            <td>${row.source}</td>
+            <td>${
+              row.reductionPercent !== null
+                ? row.reductionPercent + "%"
+                : "—"
+            }</td>
+          </tr>`
+          )
+          .join("")}
+      `;
+
+      const scroll = document.createElement("div");
+      scroll.className = "table-scroll";
+      scroll.appendChild(table);
+      filterProfileBlocks.appendChild(scroll);
+    }
+
+    for (const recommendation of advice?.recommendations ?? []) {
+      if (recommendation.priority !== "filters") {
+        continue;
+      }
+
+      const item = document.createElement("div");
+      item.className =
+        "advisor-recommendation priority-filters";
+      item.innerHTML = `<span>Filters:</span> ${recommendation.text}`;
+      filterProfileBlocks.appendChild(item);
+    }
+  }
+}
+
 // ======================================================
 // 06. ANALYSIS + SCREEN UPDATE
 // ======================================================
@@ -1902,6 +2209,8 @@ function analyzeFlight(flightIndex) {
   renderQuality(currentDataset, flight.stats);
   renderFilterAdvisor(currentDataset);
   renderAllCharts(currentDataset);
+  renderPidProfileBreakdown(pidAnalysis, lines);
+  renderFilterProfileBreakdown(currentDataset);
 
   renderLab(
     currentDataset?.labs.governor,

--- a/src/version.js
+++ b/src/version.js
@@ -7,7 +7,7 @@
 // just means silence, never an error for the pilot.
 // ======================================================
 
-export const APP_VERSION = "0.3.4";
+export const APP_VERSION = "0.3.5";
 
 const RELEASES_API =
   "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";

--- a/test/evidenceViews.test.mjs
+++ b/test/evidenceViews.test.mjs
@@ -10,6 +10,7 @@ import {
   windowStats,
   findHighestLoadEvents,
   explainLoadEvent,
+  isCollectiveDriven,
   groupByGovernorTarget
 } from "../src/analysis/evidenceViews.js";
 
@@ -111,4 +112,79 @@ test("groupByGovernorTarget clusters banks and ignores tiny groups", () => {
   assert.equal(banks[0].targetRpm, 1700);
   assert.equal(banks[1].targetRpm, 1900);
   assert.equal(banks[0].indexes.length, 200);
+});
+
+test("isCollectiveDriven needs both near-max and above-typical collective", () => {
+  // Real pitch pump: event peak near flight max, well above median
+  assert.equal(
+    isCollectiveDriven({
+      eventPeakCollective: 650,
+      flightPeakCollective: 700,
+      flightMedianCollective: 250
+    }),
+    true
+  );
+
+  // Steady hover: every moment near the (small) flight max, but
+  // never above typical — must NOT read as a pitch pump
+  assert.equal(
+    isCollectiveDriven({
+      eventPeakCollective: 260,
+      flightPeakCollective: 280,
+      flightMedianCollective: 250
+    }),
+    false
+  );
+
+  // Mild event far from the flight's real maximum
+  assert.equal(
+    isCollectiveDriven({
+      eventPeakCollective: 300,
+      flightPeakCollective: 700,
+      flightMedianCollective: 100
+    }),
+    false
+  );
+
+  assert.equal(
+    isCollectiveDriven({
+      eventPeakCollective: null,
+      flightPeakCollective: 700,
+      flightMedianCollective: 100
+    }),
+    false
+  );
+});
+
+test("collective-load outranks battery-sag and carries Daniel's wording", () => {
+  const withSag = explainLoadEvent({
+    outputPeakPercent: 90,
+    outputSaturatedShare: 0,
+    voltageSagPercent: 12,
+    collectiveDriven: true
+  });
+  assert.equal(withSag.cause, "collective-load");
+  assert.match(withSag.sentence, /hard pitch pump/);
+  assert.match(
+    withSag.sentence,
+    /not necessarily evidence of a weak pack/
+  );
+
+  const withoutSag = explainLoadEvent({
+    outputPeakPercent: 85,
+    outputSaturatedShare: 0,
+    voltageSagPercent: 3,
+    collectiveDriven: true
+  });
+  assert.equal(withoutSag.cause, "collective-load");
+  assert.match(withoutSag.sentence, /voltage holding up well/);
+
+  // Saturation still wins over everything
+  const saturated = explainLoadEvent({
+    outputPeakPercent: 100,
+    outputSaturatedShare: 0.3,
+    voltageSagPercent: 12,
+    collectiveDriven: true
+  });
+  assert.equal(saturated.cause, "headroom-limit");
 });

--- a/test/profileBreakdown.test.mjs
+++ b/test/profileBreakdown.test.mjs
@@ -1,0 +1,96 @@
+// ======================================================
+// BLACKBOX LAB — PER-PROFILE BREAKDOWN TESTS
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { longestConsecutiveRun } from "../src/analysis/evidenceViews.js";
+import { analyzeProfileResponse } from "../src/analysis/profilePidBreakdown.js";
+
+test("longestConsecutiveRun finds the biggest unbroken stretch", () => {
+  assert.deepEqual(
+    longestConsecutiveRun([1, 2, 3, 10, 11, 12, 13, 14, 30]),
+    { startIndex: 10, length: 5 }
+  );
+  assert.deepEqual(longestConsecutiveRun([7]), {
+    startIndex: 7,
+    length: 1
+  });
+  assert.equal(longestConsecutiveRun([]), null);
+});
+
+// A tiny synthetic CSV: header + rows. Bank A rows track
+// cleanly; bank B rows overshoot the setpoint by 50%.
+function syntheticLines() {
+  const lines = ['time,setpoint[0],gyroADC[0]'];
+
+  for (let i = 0; i < 60; i += 1) {
+    lines.push(`${i},100,102`); // bank A: tight tracking
+  }
+
+  for (let i = 60; i < 120; i += 1) {
+    lines.push(`${i},100,150`); // bank B: 50% overshoot
+  }
+
+  return lines;
+}
+
+test("analyzeProfileResponse measures overshoot per profile", () => {
+  const lines = syntheticLines();
+
+  const profiles = [
+    {
+      targetRpm: 1700,
+      // row indexes are relative to the header line
+      sampleIndexes: Array.from({ length: 60 }, (_, i) => i + 1)
+    },
+    {
+      targetRpm: 1900,
+      sampleIndexes: Array.from({ length: 60 }, (_, i) => i + 61)
+    }
+  ];
+
+  const results = analyzeProfileResponse({
+    lines,
+    telemetryHeaderIndex: 0,
+    headspeedProfiles: profiles,
+    setpointColumns: ["setpoint[0]"],
+    gyroColumns: ["gyroADC[0]"],
+    axisNames: ["Roll"]
+  });
+
+  assert.equal(results.length, 2);
+
+  const calm = results[0].axisResults[0];
+  assert.equal(calm.axis, "Roll");
+  assert.ok(calm.commandedSampleCount > 0);
+  assert.equal(calm.exceedanceRatePercent, 0);
+  assert.equal(calm.peakExceedancePercent, null);
+
+  const hot = results[1].axisResults[0];
+  assert.equal(hot.exceedanceRatePercent, 100);
+  assert.ok(
+    hot.peakExceedancePercent > 30 &&
+      hot.peakExceedancePercent < 50,
+    `peak exceedance should be ~40% (150 vs 100+10 deadband), got ${hot.peakExceedancePercent}`
+  );
+});
+
+test("analyzeProfileResponse handles missing columns honestly", () => {
+  const results = analyzeProfileResponse({
+    lines: syntheticLines(),
+    telemetryHeaderIndex: 0,
+    headspeedProfiles: [
+      { targetRpm: 1700, sampleIndexes: [1, 2, 3] }
+    ],
+    setpointColumns: [],
+    gyroColumns: [],
+    axisNames: ["Roll"]
+  });
+
+  assert.equal(
+    results[0].axisResults[0].exceedanceRatePercent,
+    null
+  );
+});


### PR DESCRIPTION
One-button release, as before: this PR bundles everything still open, already merged together in the right order and tested as a whole. **Merge only this one** — GitHub will automatically mark #14, #15, #17 and #18 as merged, so there's nothing else to click.

## What's inside (in merge order)

1. **#15** — README caught up with what the app does today (Downloads section first, current feature list, honest roadmap)
2. **#17** — PID Lab & Filter Lab per-headspeed-profile breakdowns
3. **#18** — collective trace + "Collective load" reading in the ESC events (your wording), and the version number in the sidebar corner
4. **#14** — v0.3.5 version bump (both files, lockstep) + the complete v0.3.5 changelog covering all of the above plus #16

Verified on the combined result: 62 tests green, UI smoke green, and a full pass with the real 3-bank log — per-bank spectra, collective-load readings, and the sidebar showing v0.3.5.

## Release steps (all in the browser)

1. **Merge pull request** below, then **Confirm merge**.
2. **Releases** page → **Draft a new release**.
3. **Choose a tag** → type exactly `v0.3.5` (with the v) → **Create new tag: v0.3.5 on publish**.
4. Title: `Blackbox Lab v0.3.5` — paste the v0.3.5 section from CHANGELOG.md as the description — **Publish release**.
5. The **Actions** tab builds the Windows/Mac/Linux installers (10–15 min). If they land on a separate draft release, open it and press **Publish**.
6. Optional check: install it — the sidebar should say **v0.3.5**, no update banner, and with your Bell log the ESC events should read "Collective load".

## Added directly to this batch

**The sample flight is now a real flight.** The synthetic tour sample left the Tuning card at "could not be measured" and showed none of the per-profile views — so the first flight most users ever load was the app at its weakest. "Try a Sample Flight" now loads the Bell flight (three headspeed banks, full ESC + governor telemetry): real tuning score, worst droop in context with your genuine governor terms, collective-load events, per-bank spectra — the whole tour. It's your flight, so merging this is your call on shipping it; say the word if you'd rather keep the synthetic one and I'll swap it back. Bundled samples are never sent to the community bucket (that guard now covers the synthetic ones too). The synthetic samples stay in samples/ as documented fixtures.

One release note addition for the description: *"The sample flight is now a real recorded flight — the one-click tour shows every card in the app."*