### PR TITLE
Sample flight: load a real flight so the tour shows everything (+ re-release steps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
   reading becomes "Collective load" — the sag was a response to
   the load, not necessarily evidence of a weak pack.
 - The sidebar now shows the app version.
+- **The sample flight is now a real flight**: "Try a Sample
+  Flight" loads a genuine recorded log with three headspeed
+  banks and full ESC + governor telemetry, so the tour shows
+  every card in the app — including the per-profile views.
+  Bundled samples are never sent to the community bucket.
 
 ### Fixed
 

--- a/Documentation/FINDING_TEST_LOGS.md
+++ b/Documentation/FINDING_TEST_LOGS.md
@@ -11,6 +11,9 @@ describing exactly what is in them (vibration frequencies,
 governor behavior, tune quality):
 
 - `sample-clean-tuned.bbl` — a healthy, well-tuned machine
+- `sample-bell-222ut.bbl` — a real recorded flight (three
+  headspeed banks, full ESC + governor telemetry) — this is the
+  one the "Try a Sample Flight" button loads
 - `sample-vibration-problem.bbl` — strong 1/rev + tail resonance
 - `sample-governor-sag.bbl` — headspeed droops under load
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ npm test         # run the test suite
 ```
 
 Then click "Open Blackbox Log" and pick a `.bbl`, `.csv` or CLI
-dump — or try `samples/sample-vibration-problem.bbl` and visit
+dump — or try `samples/sample-bell-222ut.bbl` (a real
+recorded flight) and visit
 the Filter Lab.
 
 ## Status

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -342,7 +342,7 @@ trySampleButton.addEventListener("click", async () => {
   fileStatus.textContent = "Loading sample flight...";
 
   const bytes = await window.blackboxLab.readSampleLog(
-    "sample-vibration-problem.bbl"
+    "sample-bell-222ut.bbl"
   );
 
   if (!bytes) {
@@ -352,7 +352,7 @@ trySampleButton.addEventListener("click", async () => {
 
   const file = new File(
     [new Uint8Array(bytes)],
-    "sample-vibration-problem.bbl"
+    "sample-bell-222ut.bbl"
   );
 
   await loadFromFile(file);
@@ -2343,7 +2343,12 @@ function analyzeFlight(flightIndex) {
 
   // ---- community data sharing (opt-in, anonymized) ----
   if (flight.mainFrames) {
-    maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+    // Bundled sample flights are shipped data — everyone has
+    // them, so contributing them would only fill the community
+    // bucket with identical copies.
+    if (!file.name.startsWith("sample-")) {
+      maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+    }
   }
 
   // Land the pilot on the answers, not the data.

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -28,7 +28,9 @@ const { mkdirSync } = require("node:fs");
   }
 
   await window.click("#welcomeSampleButton");
-  await window.waitForTimeout(3500);
+  // The sample is a real 134k-frame flight now — give the
+  // decoder time before asserting.
+  await window.waitForTimeout(15000);
 
   const verdictCount = await window.evaluate(
     () => document.querySelectorAll(".verdict-item").length


### PR DESCRIPTION
This one just missed the boat — the batch was already merged and tagged when it was ready, so it gets its own PR and, if you like, a fresh v0.3.5.

## The sample flight is now a real flight

Loading the synthetic tour sample left the Tuning card at "could not be measured" and showed none of the per-profile views — so the first flight most users ever open was the app at its weakest. "Try a Sample Flight" now loads the Bell flight (three headspeed banks, full ESC + governor telemetry): real tuning score, the worst droop in context with genuine governor terms, collective-load events, per-bank spectra — the complete tour.

It's your flight, so merging this is your call on shipping it; say the word if you'd rather keep the synthetic one and I'll swap it back. Two supporting details:

- **Bundled samples are never sent to the community bucket** — that guard is new and covers the synthetic samples too. Shipped data would only fill the bucket with identical copies.
- The synthetic samples stay in `samples/` as documented fixtures, and the smoke test gives the bigger flight time to decode.

Tests green, smoke green (the tour now produces 4 verdict cards and all nine tuning presets on the real flight). Built on top of current main, so your overshoot-detail fix is included.

## Re-releasing v0.3.5 with this inside (all in the browser)

Deleting a release is allowed and takes a minute — the important part is deleting the **tag** too, or the installer build won't run again:

1. Merge this PR (**Merge pull request** → **Confirm merge**).
2. **Releases** page → open **v0.3.5** → **Delete** (trash icon, top right) → confirm.
3. Go to the **Tags** page (next to Branches) → **v0.3.5** → open it → **Delete tag** → confirm.
4. **Releases** → **Draft a new release** → **Choose a tag** → type exactly `v0.3.5` → **Create new tag: v0.3.5 on publish**.
5. Title `Blackbox Lab v0.3.5`, paste the same description as before (one line worth adding: *"The sample flight is now a real recorded flight — the one-click tour shows every card in the app."*) → **Publish release**.
6. **Actions** builds the installers again (10–15 min; if they land on a draft release, publish it).

Anyone who grabbed v0.3.5 in the meantime just gets the same version with a better sample — nothing else differs.
