### PR TITLE
Welcome screen: custom rotor-and-trace mark instead of the emoji

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -777,10 +777,28 @@ body:not(.log-loaded) .loaded-only { display: none; }
   pointer-events: none;
 }
 
-.welcome-copter {
-  font-size: 44px;
-  margin-bottom: 6px;
-  filter: drop-shadow(0 6px 16px rgba(255, 196, 107, 0.25));
+.welcome-mark {
+  margin-bottom: 10px;
+  line-height: 0;
+  filter: drop-shadow(0 6px 18px rgba(111, 178, 255, 0.28))
+    drop-shadow(0 2px 8px rgba(255, 196, 107, 0.18));
+}
+
+/* The rotor idles — slow enough to feel alive, not busy. */
+.welcome-mark-rotor {
+  animation: welcome-rotor-turn 40s linear infinite;
+  transform-origin: 60px 60px;
+}
+
+@keyframes welcome-rotor-turn {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .welcome-mark-rotor {
+    animation: none;
+  }
 }
 
 .welcome-title {

--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,77 @@
              Hidden (body.log-loaded) the moment a flight is in. -->
         <section class="welcome" id="welcomeHero">
           <div class="welcome-glow" aria-hidden="true"></div>
-          <div class="welcome-copter" aria-hidden="true">🚁</div>
+          <div class="welcome-mark" aria-hidden="true">
+            <svg viewBox="0 0 120 120" width="112" height="112"
+              fill="none" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <linearGradient id="markBlade" x1="0" y1="0" x2="1" y2="1">
+                  <stop offset="0" stop-color="#eef3ff" />
+                  <stop offset="1" stop-color="#6fb2ff" />
+                </linearGradient>
+                <linearGradient id="markRing" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0" stop-color="#5b83c4" />
+                  <stop offset="0.55" stop-color="#22365a" />
+                  <stop offset="1" stop-color="#2c4470" />
+                </linearGradient>
+                <linearGradient id="markTrace" x1="0" y1="0" x2="1" y2="0">
+                  <stop offset="0" stop-color="#ffc46b" stop-opacity="0" />
+                  <stop offset="0.2" stop-color="#ffc46b" />
+                  <stop offset="0.8" stop-color="#ff9d5c" />
+                  <stop offset="1" stop-color="#ff9d5c" stop-opacity="0" />
+                </linearGradient>
+                <radialGradient id="markGlow" cx="0.5" cy="0.5" r="0.5">
+                  <stop offset="0" stop-color="#6fb2ff" stop-opacity="0.16" />
+                  <stop offset="1" stop-color="#6fb2ff" stop-opacity="0" />
+                </radialGradient>
+              </defs>
+
+              <!-- rotor disc -->
+              <circle cx="60" cy="60" r="52" fill="url(#markGlow)" />
+              <circle cx="60" cy="60" r="52"
+                stroke="url(#markRing)" stroke-width="2" />
+
+              <g class="welcome-mark-rotor">
+                <!-- motion-blur arcs at the blade tips -->
+                <path d="M 106 48 A 48 48 0 0 0 72 13.5"
+                  stroke="#6fb2ff" stroke-opacity="0.55"
+                  stroke-width="3.5" stroke-linecap="round" />
+                <path d="M 14 72 A 48 48 0 0 0 48 106.5"
+                  stroke="#6fb2ff" stroke-opacity="0.55"
+                  stroke-width="3.5" stroke-linecap="round" />
+                <path d="M 111 60 A 51 51 0 0 0 104 34"
+                  stroke="#6fb2ff" stroke-opacity="0.22"
+                  stroke-width="2.5" stroke-linecap="round" />
+                <path d="M 9 60 A 51 51 0 0 0 16 86"
+                  stroke="#6fb2ff" stroke-opacity="0.22"
+                  stroke-width="2.5" stroke-linecap="round" />
+
+                <!-- two swept blades, tapered from the root -->
+                <path d="M 58 56 C 72 47 90 36 99 30
+                         A 7.5 7.5 0 0 1 107 42
+                         C 97 49 78 59 64 65 Z"
+                  fill="url(#markBlade)" />
+                <path d="M 62 64 C 48 73 30 84 21 90
+                         A 7.5 7.5 0 0 0 13 78
+                         C 23 71 42 61 56 55 Z"
+                  fill="url(#markBlade)" opacity="0.85" />
+              </g>
+
+              <!-- telemetry trace with one vibration peak -->
+              <path d="M 4 80 C 20 80 24 74 32 74
+                       C 40 74 42 80 48 80
+                       L 55 80 L 60 52 L 65 88 L 69 80
+                       C 77 80 81 72 91 72
+                       C 101 72 106 80 116 80"
+                stroke="url(#markTrace)" stroke-width="3"
+                stroke-linecap="round" stroke-linejoin="round" />
+
+              <!-- hub -->
+              <circle cx="60" cy="60" r="6.5" fill="#101a2c"
+                stroke="#eef3ff" stroke-width="2" />
+              <circle cx="60" cy="60" r="2" fill="#ffc46b" />
+            </svg>
+          </div>
           <h2 class="welcome-title">Your flight, <span>explained.</span></h2>
           <p class="welcome-sub">
             Drop in a log straight off your flight controller and get a


### PR DESCRIPTION
Small polish for the front door: the helicopter emoji was the one thing on the welcome screen that didn't match the rest of the app — and any *specific* helicopter would be wrong for someone, with scale, 3D and F3C pilots all opening this app.

So the new mark draws what Blackbox Lab is actually about instead: a **top-down rotor disc** — swept blades, motion arcs, a hub — with a **telemetry trace running through it**, one vibration peak and all. The rotor and the data. It's a single inline SVG (no image files, no dependencies), colored to the welcome screen's existing warm-glow palette, and the rotor idles on a very slow rotation — disabled automatically for anyone with reduced-motion set in their OS.

Vincent's sending you the screenshot on Messenger. Tests and UI smoke green — it's markup and CSS only, no logic touched.

This is pure looks, so veto freely — if you'd rather keep the emoji or want the mark tweaked (bigger, stiller, different balance), say so and it's changed.
