### PR TITLE
Load progress dialog when opening a log from any screen (+ overview-or-stay choice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
   reading becomes "Collective load" — the sag was a response to
   the load, not necessarily evidence of a weak pack.
 - The sidebar now shows the app version.
+- **The sample flight is now a real flight**: "Try a Sample
+  Flight" loads a genuine recorded log with three headspeed
+  banks and full ESC + governor telemetry, so the tour shows
+  every card in the app — including the per-profile views.
+  Bundled samples are never sent to the community bucket.
 
 ### Fixed
 

--- a/Documentation/FINDING_TEST_LOGS.md
+++ b/Documentation/FINDING_TEST_LOGS.md
@@ -11,6 +11,9 @@ describing exactly what is in them (vibration frequencies,
 governor behavior, tune quality):
 
 - `sample-clean-tuned.bbl` — a healthy, well-tuned machine
+- `sample-bell-222ut.bbl` — a real recorded flight (three
+  headspeed banks, full ESC + governor telemetry) — this is the
+  one the "Try a Sample Flight" button loads
 - `sample-vibration-problem.bbl` — strong 1/rev + tail resonance
 - `sample-governor-sag.bbl` — headspeed droops under load
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ npm test         # run the test suite
 ```
 
 Then click "Open Blackbox Log" and pick a `.bbl`, `.csv` or CLI
-dump — or try `samples/sample-vibration-problem.bbl` and visit
+dump — or try `samples/sample-bell-222ut.bbl` (a real
+recorded flight) and visit
 the Filter Lab.
 
 ## Status

--- a/src/index.css
+++ b/src/index.css
@@ -662,6 +662,42 @@ body.advanced-mode details.advanced-block {
   display: none;
 }
 
+/* ---------------- load progress dialog ---------------- */
+
+.load-dialog {
+  text-align: center;
+  max-width: 380px;
+}
+
+.load-dialog .button-row {
+  justify-content: center;
+}
+
+.load-spinner {
+  width: 34px;
+  height: 34px;
+  margin: 0 auto 14px auto;
+  border-radius: 50%;
+  border: 3px solid var(--line);
+  border-top-color: var(--accent);
+  animation: load-spinner-turn 0.9s linear infinite;
+}
+
+.load-spinner[hidden] {
+  display: none;
+}
+
+@keyframes load-spinner-turn {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .load-spinner {
+    animation-duration: 2.5s;
+  }
+}
+
 .overlay-dialog {
   width: min(520px, 92vw);
   background: var(--card);

--- a/src/index.html
+++ b/src/index.html
@@ -838,6 +838,24 @@ current demand; the steady downward slope is normal discharge.
     </main>
   </div>
 
+  <!-- Load progress: shown when a log is opened from any screen
+       other than Home, where the inline status is not visible. -->
+  <div class="overlay" id="loadProgress" hidden>
+    <div class="overlay-dialog load-dialog">
+      <div class="load-spinner" id="loadSpinner" aria-hidden="true"></div>
+      <h3 id="loadProgressTitle">Reading your flight…</h3>
+      <p id="loadProgressText"></p>
+      <div class="button-row" id="loadProgressActions" hidden>
+        <button class="primary-button" id="loadGoOverview">
+          Go to the overview
+        </button>
+        <button class="secondary-button" id="loadStayHere">
+          Stay on this page
+        </button>
+      </div>
+    </div>
+  </div>
+
   <div class="overlay" id="contributeAsk" hidden>
     <div class="overlay-dialog">
       <h3>Help improve Blackbox Lab?</h3>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -277,15 +277,80 @@ openLogLock.addEventListener("click", (event) => {
 
 let loadedLog = null;
 
+// ---- load progress overlay ----
+// The inline status lives on Home. A log opened from any other
+// screen (sidebar button, drag & drop) would load invisibly and
+// feel like a hang — so those loads get a small progress dialog,
+// which ends by asking: jump to the overview, or stay here?
+const loadProgress = el("loadProgress");
+const loadProgressTitle = el("loadProgressTitle");
+const loadProgressText = el("loadProgressText");
+const loadProgressActions = el("loadProgressActions");
+const loadSpinner = el("loadSpinner");
+const loadGoOverview = el("loadGoOverview");
+const loadStayHere = el("loadStayHere");
+
+function currentScreenName() {
+  return (
+    document.querySelector("[data-screen].screen-active")?.dataset
+      .screen ?? "home"
+  );
+}
+
+function beginLoadProgress() {
+  if (currentScreenName() === "home") {
+    return;
+  }
+
+  loadProgressTitle.textContent = "Reading your flight…";
+  loadProgressText.textContent = "";
+  loadSpinner.hidden = false;
+  loadProgressActions.hidden = true;
+  loadProgress.hidden = false;
+}
+
+function setLoadStatus(text) {
+  fileStatus.textContent = text;
+
+  if (!loadProgress.hidden) {
+    loadProgressText.textContent = text;
+  }
+}
+
+function finishLoadProgress(succeeded) {
+  if (loadProgress.hidden) {
+    return;
+  }
+
+  loadProgressTitle.textContent = succeeded
+    ? "Flight analyzed"
+    : "Could not read this log";
+  loadSpinner.hidden = true;
+  loadProgressActions.hidden = false;
+}
+
+loadGoOverview.addEventListener("click", () => {
+  loadProgress.hidden = true;
+  navigation.showScreen("home");
+  document.querySelector(".workspace").scrollTop = 0;
+});
+
+loadStayHere.addEventListener("click", () => {
+  loadProgress.hidden = true;
+});
+
 async function loadFromFile(file) {
-  fileStatus.textContent = `Reading ${file.name}...`;
+  beginLoadProgress();
+  setLoadStatus(`Reading ${file.name}...`);
   await new Promise((resolve) => setTimeout(resolve, 30));
 
   const logData = await readLogFile(file);
 
   if (!logData || logData.flights.length === 0) {
-    fileStatus.textContent =
-      "Could not read any flight data from this file.";
+    setLoadStatus(
+      "Could not read any flight data from this file."
+    );
+    finishLoadProgress(false);
     return;
   }
 
@@ -308,14 +373,20 @@ async function loadFromFile(file) {
 
   flightPicker.hidden = logData.flights.length < 2;
 
-  fileStatus.textContent =
-    "Analyzing flight... (big logs take a few seconds)";
+  setLoadStatus(
+    "Analyzing flight... (big logs take a few seconds)"
+  );
   await new Promise((resolve) => setTimeout(resolve, 30));
 
   analyzeFlight(0);
 
   // Swap the welcome hero for the working Home layout.
   document.body.classList.add("log-loaded");
+
+  if (!loadProgress.hidden) {
+    loadProgressText.textContent = `${file.name} analyzed — the verdict is ready on the overview.`;
+  }
+  finishLoadProgress(true);
 }
 
 logFileInput.addEventListener("change", async () => {
@@ -323,8 +394,10 @@ logFileInput.addEventListener("change", async () => {
     try {
       await loadFromFile(logFileInput.files[0]);
     } catch (error) {
-      fileStatus.textContent =
-        "Something went wrong reading this log: " + error.message;
+      setLoadStatus(
+        "Something went wrong reading this log: " + error.message
+      );
+      finishLoadProgress(false);
     }
   }
 
@@ -2351,9 +2424,13 @@ function analyzeFlight(flightIndex) {
     }
   }
 
-  // Land the pilot on the answers, not the data.
-  navigation.showScreen("home");
-  document.querySelector(".workspace").scrollTop = 0;
+  // Land the pilot on the answers, not the data — unless the
+  // load-progress dialog is up: then the jump is the pilot's
+  // choice ("Go to the overview" vs "Stay on this page").
+  if (loadProgress.hidden) {
+    navigation.showScreen("home");
+    document.querySelector(".workspace").scrollTop = 0;
+  }
 }
 
 // ======================================================
@@ -2890,8 +2967,10 @@ window.addEventListener("drop", async (event) => {
   try {
     await loadFromFile(file);
   } catch (error) {
-    fileStatus.textContent =
-      "Something went wrong reading this log: " + error.message;
+    setLoadStatus(
+      "Something went wrong reading this log: " + error.message
+    );
+    finishLoadProgress(false);
   }
 });
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -342,7 +342,7 @@ trySampleButton.addEventListener("click", async () => {
   fileStatus.textContent = "Loading sample flight...";
 
   const bytes = await window.blackboxLab.readSampleLog(
-    "sample-vibration-problem.bbl"
+    "sample-bell-222ut.bbl"
   );
 
   if (!bytes) {
@@ -352,7 +352,7 @@ trySampleButton.addEventListener("click", async () => {
 
   const file = new File(
     [new Uint8Array(bytes)],
-    "sample-vibration-problem.bbl"
+    "sample-bell-222ut.bbl"
   );
 
   await loadFromFile(file);
@@ -2343,7 +2343,12 @@ function analyzeFlight(flightIndex) {
 
   // ---- community data sharing (opt-in, anonymized) ----
   if (flight.mainFrames) {
-    maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+    // Bundled sample flights are shipped data — everyone has
+    // them, so contributing them would only fill the community
+    // bucket with identical copies.
+    if (!file.name.startsWith("sample-")) {
+      maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+    }
   }
 
   // Land the pilot on the answers, not the data.

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -107,6 +107,23 @@ const { mkdirSync } = require("node:fs");
   console.log("compare rows:", compareRowCount, "| summary:", compareSummary);
   await window.screenshot({ path: "smoke-shots/08-compare.png" });
 
+  // ---- load-from-another-screen: progress dialog ----
+  await window.click('.nav-button[data-target="viewer"]');
+  await window.waitForTimeout(300);
+  await window.setInputFiles("#logFileInput", "samples/sample-clean-tuned.bbl");
+  await window.waitForSelector("#loadProgress:not([hidden])", { timeout: 5000 });
+  await window.waitForSelector("#loadProgressActions:not([hidden])", { timeout: 30000 });
+  const loadTitle = await window.textContent("#loadProgressTitle");
+  await window.click("#loadStayHere");
+  const overlayState = await window.evaluate(() => ({
+    overlayHidden: document.getElementById("loadProgress").hidden,
+    screen: document.querySelector("[data-screen].screen-active")?.dataset.screen
+  }));
+  if (!overlayState.overlayHidden || overlayState.screen !== "viewer") {
+    throw new Error("load progress dialog misbehaved: " + JSON.stringify(overlayState));
+  }
+  console.log("load progress dialog ok:", loadTitle, "| stayed on:", overlayState.screen);
+
   // ---- health record ----
   await window.click('.nav-button[data-target="history"]');
   await window.waitForTimeout(450);

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -28,7 +28,9 @@ const { mkdirSync } = require("node:fs");
   }
 
   await window.click("#welcomeSampleButton");
-  await window.waitForTimeout(3500);
+  // The sample is a real 134k-frame flight now — give the
+  // decoder time before asserting.
+  await window.waitForTimeout(15000);
 
   const verdictCount = await window.evaluate(
     () => document.querySelectorAll(".verdict-item").length


### PR DESCRIPTION
UX gap from real use: opening a log from the sidebar (or dropping one onto the window) while on any screen other than Home loaded invisibly — the status text lives on Home, so a big log felt like the app had crashed.

## What's new

- Loads started away from Home now show a **small progress dialog**: spinner plus the same status messages the Home screen shows ("Reading…", "Analyzing flight…").
- When the flight is ready, the dialog asks what you'd expect: **Go to the overview** or **Stay on this page** — there are good reasons for both (fresh log → verdict; re-checking something in a lab → stay put).
- The automatic jump-to-the-verdict after a load still happens for Home loads exactly as before; it just yields to the dialog's question when the dialog is the one in charge.
- Works for the file picker and drag & drop alike; failures show in the same dialog instead of dying silently.

The smoke test now drives the whole flow — open a log from the viewer screen, watch the dialog, choose Stay, assert the app actually stays.

**Note: this builds on top of #20** (they touch neighboring code) — merge #20 first, or merge just this one and it brings #20 along.

Tests green, smoke green.
