### PR TITLE
Fix PID tracking with zero governor-target data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,20 @@
 # ======================================================
 # BLACKBOX LAB — RELEASE WORKFLOW
 #
-# Releasing: bump version in package.json, then
-#   git tag v0.4.0 && git push --tags
-# GitHub builds Windows, macOS and Linux packages and
-# attaches them to a DRAFT release for you to publish.
+# Releasing, in order:
+#   1. bump the version in BOTH package.json and
+#      src/version.js — they must match (a test checks it)
+#   2. merge that to main
+#   3. tag main v0.3.7 and push the tag
+#
+# The tag names the release; package.json names every
+# installer and is what the app reports about itself, so
+# all three are kept on the same number. The first job
+# below confirms that before anything is built.
+#
+# GitHub builds Windows, macOS (Apple Silicon AND Intel)
+# and Linux packages and attaches them to a DRAFT release
+# for you to publish.
 # ======================================================
 
 name: Release
@@ -17,11 +27,39 @@ permissions:
   contents: write
 
 jobs:
+  # Confirms the three version sources agree before the build
+  # starts, so nothing is packaged under the wrong number.
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag must match package.json and src/version.js
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          APP="$(node -p "require('fs').readFileSync('src/version.js','utf8').match(/APP_VERSION = .([0-9.]+)./)[1]")"
+          echo "tag=$TAG  package.json=$PKG  src/version.js=$APP"
+          if [ "$TAG" != "$PKG" ] || [ "$TAG" != "$APP" ]; then
+            echo "::error::Version mismatch — tag $TAG, package.json $PKG, src/version.js $APP. Set both files to $TAG on main, then delete this tag and tag again so the installers carry the right number."
+            exit 1
+          fi
+
   build:
+    needs: check-version
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+          - os: ubuntu-latest
+          # Apple Silicon (M1 and newer) — the runner's own architecture
+          - os: macos-latest
+            arch: arm64
+          # Intel Macs. Built on the same runner using Electron's x64
+          # binary: the app is pure JavaScript, so nothing needs an
+          # Intel machine to compile. Older Macs get their own zip.
+          - os: macos-latest
+            arch: x64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +68,7 @@ jobs:
           node-version: 22
       - run: npm ci
       - run: npm test
-      - run: npm run make
+      - run: npm run make ${{ matrix.arch && format('-- --arch={0}', matrix.arch) || '' }}
       - name: Attach packages to draft release
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v0.3.7 — release plumbing
+
+### Added
+
+- **Downloads for Intel Macs.** Releases now build a
+  `Blackbox.Lab-darwin-x64-…zip` alongside the Apple Silicon package,
+  so Macs from before 2020 are covered. Pick the one matching your
+  machine — About This Mac says "Apple M…" or "Intel Core…".
+- `Documentation/RELEASING.md` — the release steps in the browser,
+  what each version file controls, and what to check if a build does
+  not start.
+
+### Changed
+
+- The release build confirms the tag and the two version files agree
+  before it builds anything, so any mismatch surfaces in about a
+  minute with a message naming the file to update.
+
 ## v0.3.5 — the tuning charts release
 
 ### Added

--- a/Documentation/RELEASING.md
+++ b/Documentation/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing Blackbox Lab
+
+Everything here is done in the browser on github.com — no git, no
+terminal.
+
+## The one rule
+
+**The version lives in two files, and the tag does not change them.**
+
+| where | what it controls |
+|---|---|
+| `package.json` | the name of every installer — `Blackbox.Lab-0.3.7.Setup.exe` — and the version the operating system sees |
+| `src/version.js` (`APP_VERSION`) | the version shown in the sidebar, and the one the update check compares against the latest release |
+| the git tag `v0.3.7` | the name of the release page, and the trigger that starts the build |
+
+All three need to say the same thing. The two files are bumped for
+you in the pull request that prepares a release, so in practice:
+**merge the release PR first, tag second.**
+
+The build checks all three before it starts. If they do not match you
+get a red ✗ within a minute naming the file to update, so nothing is
+built under the wrong number.
+
+## Steps
+
+1. **Merge the release pull request.** It bumps both files and adds
+   the changelog entry.
+2. Go to **Releases → Draft a new release**.
+3. **Choose a tag** → type `v0.3.7` → *Create new tag on publish*.
+   The `v` matters: the build only listens for tags starting with `v`.
+4. Title and description — paste the release text.
+5. **Publish release.**
+6. Open the **Actions** tab. A run called *Release* starts. It takes
+   roughly 15–25 minutes and produces a **draft** release with the
+   installers attached.
+7. When it finishes, go back to **Releases**, open the draft, check
+   the file names carry the right version, and **Publish** it.
+
+## What gets built
+
+| platform | file |
+|---|---|
+| Windows | `Blackbox.Lab-0.3.7.Setup.exe` (plus zip and nupkg) |
+| macOS, Apple Silicon (M1 and newer) | `Blackbox.Lab-darwin-arm64-0.3.7.zip` |
+| macOS, Intel (2020 and older) | `Blackbox.Lab-darwin-x64-0.3.7.zip` |
+| Linux | `.deb`, `.rpm` and a zip |
+
+Two Mac files is correct. An Apple Silicon Mac cannot run the Intel
+build well and an Intel Mac cannot run the Apple Silicon build at
+all, so pilots pick the one matching their machine — **About This
+Mac** tells them which: "Apple M…" means Apple Silicon, "Intel Core…"
+means Intel.
+
+Neither Mac build is code-signed, so the first launch needs
+**right-click → Open** rather than a double-click. That is normal for
+free unsigned apps and only has to be done once.
+
+## If something goes wrong
+
+**The build never started.** The tag is missing its `v`, or the
+release was created on a tag that already existed. A release published
+onto an existing tag does not trigger anything — delete the release
+*and the tag*, then create both fresh.
+
+**Red ✗ saying "Version mismatch".** The tag and the version files
+are not on the same number yet. Merge the version bump to main, delete
+the tag, and tag again.
+
+**One platform failed, the others worked.** The failed platform simply
+has no file on the draft. Read its log in Actions; the other
+installers are still good and can be published.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Ready-made installers for **Windows, macOS and Linux** are on the
 [Releases page](https://github.com/hillbilly1975/Blackbox_Lab/releases/latest)
 — download, install, open a log. No build tools needed.
 
+macOS comes in two builds: `darwin-arm64` for Apple Silicon (M1 and
+newer) and `darwin-x64` for Intel Macs. **About This Mac** tells you
+which you have. Neither is code-signed, so open the app the first
+time with right-click → Open.
+
 ---
 
 ## What It Looks Like

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blackbox-lab",
   "productName": "Blackbox Lab",
-  "version": "0.3.5",
+  "version": "0.3.7",
   "description": "Rotorflight Blackbox analysis suite \u2014 simple first, deeper when you want it.",
   "main": "src/index.js",
   "private": true,

--- a/src/analysis/flightPhase.js
+++ b/src/analysis/flightPhase.js
@@ -365,7 +365,12 @@ export function detectStableFlightPhase({
 }) {
 const hasGovernorTarget =
   governorTarget.length > 0;
-
+console.log("FLIGHT PHASE DEBUG", {
+  timeCount: timeSeconds.length,
+  headspeedCount: headspeed.length,
+  governorTargetCount: governorTarget?.length ?? 0,
+  hasGovernorTarget
+});
 const sampleCount =
   hasGovernorTarget
     ? Math.min(

--- a/src/analysis/logAnalysisBuilder.js
+++ b/src/analysis/logAnalysisBuilder.js
@@ -55,38 +55,54 @@ const profileSamples =
     : headspeedValues.map((measuredRpm, index) => ({
         rowIndex: null,
         measuredRpm: Number(measuredRpm),
-        targetRpm: Number(governorTargetValues[index])
+       targetRpm:
+  Number(governorTargetValues[index]) > 0
+    ? Number(governorTargetValues[index])
+    : Number(measuredRpm)
       }));
 
  const sampleCount = profileSamples.length;
 
+   
   const profileGroups = new Map();
-
+const rejected = {
+   seen: 0,
+  unstable: 0,
+  invalidNumbers: 0,
+  targetTooLow: 0,
+  outsideRange: 0,
+  accepted: 0
+};
   for (
   let sampleIndex = 0;
   sampleIndex < profileSamples.length;
   sampleIndex += 1
 ) {
   const sample = profileSamples[sampleIndex];
-
+rejected.seen += 1;
   if (
-    stableFlightPhase &&
-    !stableSampleIndexes.has(sampleIndex)
-  ) {
-    continue;
-  }
+  stableFlightPhase &&
+  !stableSampleIndexes.has(sampleIndex)
+) {
+  rejected.unstable += 1;
+  continue;
+}
+  
 
   const measuredRpm = Number(sample.measuredRpm);
   const targetRpm = Number(sample.targetRpm);
 
     if (
-      !Number.isFinite(measuredRpm) ||
-      !Number.isFinite(targetRpm) ||
-      targetRpm < 300
-    ) {
-      continue;
-    }
-
+  !Number.isFinite(measuredRpm) ||
+  !Number.isFinite(targetRpm)
+) {
+  rejected.invalidNumbers += 1;
+  continue;
+}
+if (targetRpm < 300) {
+  rejected.targetTooLow += 1;
+  continue;
+}
     // Ignore spool-up, spool-down, and large transient errors.
     const minimumStableRpm = targetRpm * 0.7;
     const maximumStableRpm = targetRpm * 1.3;
@@ -129,6 +145,7 @@ const profileSamples =
       measuredRpm
     );
   }
+ 
 
   return Array.from(profileGroups.values())
     .filter((profile) => profile.sampleCount >= 1000)
@@ -287,7 +304,11 @@ const alignedHeadspeedSamples = headspeedSamples
     rowIndex: sample.rowIndex,
     timeSeconds: timeByRow.get(sample.rowIndex),
     measuredRpm: sample.value,
-    targetRpm: governorTargetByRow.get(sample.rowIndex)
+    
+  targetRpm:
+  Number(governorTargetByRow.get(sample.rowIndex)) > 0
+    ? Number(governorTargetByRow.get(sample.rowIndex))
+    : Number(sample.value)
   }))
   .filter((sample) =>
     Number.isFinite(sample.timeSeconds) &&
@@ -404,7 +425,7 @@ const headspeedProfiles =
 pidAnalysis = analyzePids(
   analysisContext,
   lines,
-  filterAnalysis?.profileSpecificFilterAnalysis ?? []
+ headspeedProfiles
 );
 const governorLabSamples = headspeedSamples
   .map((sample) => ({

--- a/src/analysis/pidAnalysis.js
+++ b/src/analysis/pidAnalysis.js
@@ -108,7 +108,7 @@ const axisSetpointColumns =
     "gyrofiltered"
   ]
 ).filter((columnName) =>
-  /^gyroADC\[[0-2]\]$/i.test(
+  /^"?(?:gyroADC|gyroFiltered)\[[0-2]\]"?$/i.test(
     String(columnName).trim()
   )
 );
@@ -220,7 +220,22 @@ const filteredGyroValues =
         )
       : []
   }));
- 
+ console.log(
+  "PID DEBUG " +
+    JSON.stringify({
+      telemetryHeaderIndex,
+      stableRowCount: stableRowIndexes.length,
+      setpointColumns: axisSetpointColumns,
+      gyroColumns: filteredGyroColumns,
+      setpointValueCounts: axisSetpointValues.map(
+        (result) => result.values.length
+      ),
+      gyroValueCounts: filteredGyroValues.map(
+        (result) => result.values.length
+      ),
+      firstStableRows: stableRowIndexes.slice(0, 5)
+    })
+);
 const axisErrorValues =
   recordedAxisErrorValues.length === 3
     ? recordedAxisErrorValues

--- a/src/version.js
+++ b/src/version.js
@@ -7,7 +7,7 @@
 // just means silence, never an error for the pilot.
 // ======================================================
 
-export const APP_VERSION = "0.3.5";
+export const APP_VERSION = "0.3.7";
 
 const RELEASES_API =
   "https://api.github.com/repos/hillbilly1975/Blackbox_Lab/releases/latest";


### PR DESCRIPTION
## Summary

- Fixes PID tracking when governor-target telemetry is present but contains zero values
- Falls back to measured headspeed so valid headspeed profiles can still be detected
- Restores stable-flight sample alignment and PID tracking by headspeed bank
- Includes Vincent’s release-build updates for Intel Mac downloads and pre-build version checking

## Validation

- PID tracking now produces headspeed-profile results
- Working tree is clean
- 61 tests passed
- 0 tests failed