### PR TITLE
Support logs without an RPM sensor, and make multi-flight logs read unambiguously

### DIFF
--- a/src/analysis/batteryLabAnalysis.js
+++ b/src/analysis/batteryLabAnalysis.js
@@ -165,8 +165,11 @@ export function analyzeBatteryLab({
   if (stableIndexes.length < 100) {
     return {
       status: "insufficient",
+      hasRotorSpeedData: flightPhase.hasRotorSpeedData !== false,
       story:
-        "No stable governed-flight section was long enough for a reliable battery assessment.",
+        flightPhase.hasRotorSpeedData === false
+          ? "This log contains no rotor-speed data, so a steady-load section could not be identified for a battery assessment."
+          : "No stable governed-flight section was long enough for a reliable battery assessment.",
       metrics: [
         {
           label: "Stable samples",

--- a/src/analysis/filterAnalysis.js
+++ b/src/analysis/filterAnalysis.js
@@ -751,10 +751,42 @@ const timeSeconds = timeColumn.values.map((value) =>
     : null
 );
 
+// Aircraft without an RPM sensor log headspeed as zero, so
+// airframe motion is offered as a second way to find the
+// flight section. It is only used when rotor speed is absent.
+const activityGyroColumns = [
+  extractAlignedNumericColumn(lines, telemetryHeaderIndex, [
+    /^gyroadc\[0\]$/i,
+    /^gyroraw\[0\]$/i
+  ]),
+  extractAlignedNumericColumn(lines, telemetryHeaderIndex, [
+    /^gyroadc\[1\]$/i,
+    /^gyroraw\[1\]$/i
+  ]),
+  extractAlignedNumericColumn(lines, telemetryHeaderIndex, [
+    /^gyroadc\[2\]$/i,
+    /^gyroraw\[2\]$/i
+  ])
+].filter((column) => column.values.length > 0);
+
+const motionActivity =
+  activityGyroColumns.length > 0
+    ? timeSeconds.map((_, index) =>
+        activityGyroColumns.reduce((total, column) => {
+          const value = Number(column.values[index]);
+
+          return (
+            total + (Number.isFinite(value) ? Math.abs(value) : 0)
+          );
+        }, 0)
+      )
+    : [];
+
 const stableFlightPhase = detectStableFlightPhase({
   timeSeconds,
   headspeed: headspeedColumn.values,
-  governorTarget: governorTargetColumn.values
+  governorTarget: governorTargetColumn.values,
+  activity: motionActivity
 });
 
 const sampleRate =

--- a/src/analysis/flightPhase.js
+++ b/src/analysis/flightPhase.js
@@ -358,30 +358,178 @@ function keepStableSegments({
   };
 }
 
+// Rotor speed is the preferred way to find steady flight.
+// Aircraft without an RPM sensor (nitro and turbine models,
+// or electric models flown without the sensor wired) log
+// headspeed as a constant zero, so the check below decides
+// which detection basis this log can support.
+export function hasUsableRotorSpeed(values) {
+  if (!Array.isArray(values)) {
+    return false;
+  }
+
+  return values.some((value) => {
+    const numericValue = Number(value);
+
+    return (
+      Number.isFinite(numericValue) &&
+      numericValue >= 500
+    );
+  });
+}
+
+function buildRollingMean(values, windowSamples) {
+  const smoothed = new Array(values.length).fill(null);
+
+  const half = Math.max(1, Math.round(windowSamples / 2));
+
+  let runningTotal = 0;
+  let runningCount = 0;
+
+  for (
+    let index = 0;
+    index < values.length + half;
+    index += 1
+  ) {
+    if (index < values.length) {
+      const entering = Number(values[index]);
+
+      if (Number.isFinite(entering)) {
+        runningTotal += entering;
+        runningCount += 1;
+      }
+    }
+
+    const leavingIndex = index - 2 * half;
+
+    if (leavingIndex >= 0) {
+      const leaving = Number(values[leavingIndex]);
+
+      if (Number.isFinite(leaving)) {
+        runningTotal -= leaving;
+        runningCount -= 1;
+      }
+    }
+
+    const centre = index - half;
+
+    if (centre >= 0 && centre < values.length) {
+      smoothed[centre] =
+        runningCount > 0
+          ? runningTotal / runningCount
+          : null;
+    }
+  }
+
+  return smoothed;
+}
+
+function getPercentile(values, fraction) {
+  const usable = values
+    .filter((value) => Number.isFinite(Number(value)))
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  if (usable.length === 0) {
+    return null;
+  }
+
+  const position = Math.min(
+    usable.length - 1,
+    Math.max(0, Math.round((usable.length - 1) * fraction))
+  );
+
+  return usable[position];
+}
+
+// Without rotor speed, sustained airframe motion is what
+// separates flight from sitting on the ground. The quiet
+// and busy ends of the recording set the threshold, so the
+// result does not depend on any absolute gyro magnitude.
+function buildActivityMask({
+  activity,
+  sampleCount,
+  sampleRateHz
+}) {
+  const windowSamples = Math.max(
+    3,
+    Math.round(sampleRateHz)
+  );
+
+  const smoothed = buildRollingMean(
+    activity.slice(0, sampleCount),
+    windowSamples
+  );
+
+  const quietLevel = getPercentile(smoothed, 0.1);
+  const busyLevel = getPercentile(smoothed, 0.9);
+
+  if (
+    !Number.isFinite(quietLevel) ||
+    !Number.isFinite(busyLevel) ||
+    busyLevel <= 0
+  ) {
+    return null;
+  }
+
+  // A model sitting on the ground still logs a little gyro
+  // noise, so contrast alone is not enough to call something
+  // flight — noise against quieter noise still forms a ratio.
+  // The busy end must also clear a floor of real rotation.
+  // The floor is deliberately far below any flying model, so
+  // gentle hovering still qualifies.
+  const MINIMUM_FLIGHT_ROTATION = 15;
+
+  if (
+    busyLevel < MINIMUM_FLIGHT_ROTATION ||
+    busyLevel < quietLevel * 1.5
+  ) {
+    return null;
+  }
+
+  const threshold =
+    quietLevel + (busyLevel - quietLevel) * 0.25;
+
+  const mask = new Array(sampleCount).fill(false);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const value = smoothed[index];
+
+    if (Number.isFinite(value) && value >= threshold) {
+      mask[index] = true;
+    }
+  }
+
+  return mask;
+}
+
 export function detectStableFlightPhase({
   timeSeconds = [],
   headspeed = [],
-  governorTarget = []
+  governorTarget = [],
+  activity = []
 }) {
 const hasGovernorTarget =
   governorTarget.length > 0;
-console.log("FLIGHT PHASE DEBUG", {
-  timeCount: timeSeconds.length,
-  headspeedCount: headspeed.length,
-  governorTargetCount: governorTarget?.length ?? 0,
-  hasGovernorTarget
-});
+const hasRotorSpeedData = hasUsableRotorSpeed(headspeed);
+const hasActivitySignal =
+  Array.isArray(activity) && activity.length > 0;
 const sampleCount =
-  hasGovernorTarget
+  !hasRotorSpeedData && hasActivitySignal
     ? Math.min(
         timeSeconds.length,
-        headspeed.length,
-        governorTarget.length
+        activity.length
       )
-    : Math.min(
-        timeSeconds.length,
-        headspeed.length
-      );
+    : hasGovernorTarget
+      ? Math.min(
+          timeSeconds.length,
+          headspeed.length,
+          governorTarget.length
+        )
+      : Math.min(
+          timeSeconds.length,
+          headspeed.length
+        );
 
   if (sampleCount < 100) {
     return {
@@ -390,6 +538,8 @@ const sampleCount =
       stableIndexes: [],
       segments: [],
       stableSampleCount: 0,
+      hasRotorSpeedData,
+      basis: "none",
       reason: "Not enough aligned samples were available."
     };
   }
@@ -422,19 +572,55 @@ const sampleCount =
     Math.round(sampleRateHz * 3)
   );
 
-  const candidateMask = buildCandidateMask({
-  timeSeconds: alignedTime,
-  headspeed: alignedHeadspeed,
-  governorTarget: alignedTarget,
-  sampleCount
-});
+  const activityMask =
+    !hasRotorSpeedData && hasActivitySignal
+      ? buildActivityMask({
+          activity,
+          sampleCount,
+          sampleRateHz
+        })
+      : null;
+
+  const basis = hasRotorSpeedData
+    ? "headspeed"
+    : activityMask
+      ? "activity"
+      : "none";
+
+  if (basis === "none") {
+    return {
+      sampleRateHz,
+      stableMask: new Array(sampleCount).fill(false),
+      stableIndexes: [],
+      segments: [],
+      stableSampleCount: 0,
+      hasRotorSpeedData,
+      basis,
+      movedDuringRecording: hasActivitySignal ? false : null,
+      reason: hasActivitySignal
+        ? "This log contains no rotor-speed data, and the airframe did not move during the recording, so no flight section could be identified."
+        : "This log contains no rotor-speed data, so a governed-flight section could not be identified."
+    };
+  }
+
+  const candidateMask =
+    basis === "activity"
+      ? activityMask
+      : buildCandidateMask({
+          timeSeconds: alignedTime,
+          headspeed: alignedHeadspeed,
+          governorTarget: alignedTarget,
+          sampleCount
+        });
 
   const transitionCleanedMask =
-    removeTargetTransitions({
-      mask: candidateMask,
-      governorTarget: alignedTarget,
-      transitionWindowSamples
-    });
+    basis === "activity"
+      ? candidateMask
+      : removeTargetTransitions({
+          mask: candidateMask,
+          governorTarget: alignedTarget,
+          transitionWindowSamples
+        });
 
   const {
     stableMask,
@@ -463,10 +649,17 @@ const sampleCount =
     stableIndexes,
     segments,
     stableSampleCount: stableIndexes.length,
+    hasRotorSpeedData,
+    basis,
+    movedDuringRecording: basis === "activity" ? true : null,
     reason:
       stableIndexes.length > 0
-        ? "Stable governed-flight samples were detected."
-        : "No stable governed-flight segment passed the phase checks."
+        ? basis === "activity"
+          ? "Steady flight was detected from airframe motion, because this log contains no rotor-speed data."
+          : "Stable governed-flight samples were detected."
+        : basis === "activity"
+          ? "The airframe moved, but no single section was steady for long enough to measure."
+          : "No stable governed-flight segment passed the phase checks."
   };
 }
 

--- a/src/analysis/flightVerdict.js
+++ b/src/analysis/flightVerdict.js
@@ -322,11 +322,24 @@ function rotorSpeedVerdictFromLab(governorLab) {
       key: "rotor",
       title: "Rotor Speed",
       status: "watch",
-      headline: "Governor hold could not be measured",
+      headline:
+        governorLab.movedDuringRecording === false
+          ? "No flight found in this recording"
+          : governorLab.hasRotorSpeedData === false
+            ? "No rotor-speed data in this log"
+            : "Governor hold could not be measured",
       detail:
-        "No stable governed-flight section was long enough for a reliable governor result.",
+        governorLab.movedDuringRecording === false
+          ? "The sticks and servos move in this log, but the airframe itself never does, and no rotor speed was recorded. That is the signature of a bench or ground run rather than a flight."
+          : governorLab.hasRotorSpeedData === false
+            ? "This log records no headspeed, which is normal for a model flown without an RPM sensor. Governor hold is measured against rotor speed, so it cannot be scored from this flight."
+            : "No stable governed-flight section was long enough for a reliable governor result.",
       action:
-        "Do not change governor settings from this flight.",
+        governorLab.movedDuringRecording === false
+          ? "Open a log recorded in flight. If this was a flight, check that the gyro and RPM sensor are being logged."
+          : governorLab.hasRotorSpeedData === false
+            ? "Nothing to fix in the log. Fit and enable an RPM sensor if you want governor scoring."
+            : "Do not change governor settings from this flight.",
       screen: "governor",
       evidence: "Headspeed vs Target chart, Governor Lab"
     };
@@ -398,11 +411,18 @@ function batteryVerdictFromLab(batteryLab) {
       key: "battery",
       title: "Battery",
       status: "watch",
-      headline: "Battery condition could not be assessed",
+      headline:
+        batteryLab.hasRotorSpeedData === false
+          ? "Battery assessment needs rotor-speed data"
+          : "Battery condition could not be assessed",
       detail:
-        "No stable governed-flight section was long enough for a reliable battery result.",
+        batteryLab.hasRotorSpeedData === false
+          ? "Pack condition is judged over a steady-load section, which this app identifies from rotor speed. This log records none, so the pack cannot be scored from this flight."
+          : "No stable governed-flight section was long enough for a reliable battery result.",
       action:
-        "Do not judge the pack from this flight alone.",
+        batteryLab.hasRotorSpeedData === false
+          ? "Nothing to fix in the log. Use the Voltage Over the Flight chart to view the pack directly."
+          : "Do not judge the pack from this flight alone.",
       screen: "battery",
       evidence: "Voltage Over the Flight chart, Battery Lab"
     };

--- a/src/analysis/governorLabAnalysis.js
+++ b/src/analysis/governorLabAnalysis.js
@@ -18,7 +18,8 @@ import {
 export function analyzeGovernorLab({
   timeSeconds,
   headspeed,
-  governorTarget
+  governorTarget,
+  activity = []
 }) {
   if (
     !Array.isArray(timeSeconds) ||
@@ -57,7 +58,8 @@ if (
   const flightPhase = detectStableFlightPhase({
     timeSeconds,
     headspeed,
-    governorTarget
+    governorTarget,
+    activity
   });
 
   const stableIndexes = flightPhase.stableIndexes;
@@ -69,8 +71,15 @@ if (
     return {
       score: null,
       status: "insufficient",
+      hasRotorSpeedData: flightPhase.hasRotorSpeedData !== false,
+      movedDuringRecording:
+        flightPhase.movedDuringRecording ?? null,
       story:
-        "No stable governed-flight section was long enough for a reliable governor assessment.",
+        flightPhase.movedDuringRecording === false
+          ? "The airframe did not move during this recording, and no rotor speed was logged, so there is no flight to assess."
+          : flightPhase.hasRotorSpeedData === false
+            ? "This log contains no rotor-speed data, so governor behaviour cannot be assessed. Governor scoring needs an RPM sensor feeding headspeed."
+            : "No stable governed-flight section was long enough for a reliable governor assessment.",
       droopRpm: null,
       droopPercent: null,
       droopTimeSeconds: null,

--- a/src/analysis/logAnalysisBuilder.js
+++ b/src/analysis/logAnalysisBuilder.js
@@ -427,11 +427,65 @@ pidAnalysis = analyzePids(
   lines,
  headspeedProfiles
 );
+// Airframe motion, used only when no rotor speed was logged.
+// It lets the app tell "no RPM sensor" apart from "this was a
+// bench run and the model never moved".
+const gyroActivityByRow = (() => {
+  const axisSamples = [0, 1, 2]
+    .map((axis) => {
+      const columnName =
+        headers.find(
+          (header) =>
+            header.toLowerCase() === `gyroadc[${axis}]`
+        ) ??
+        headers.find(
+          (header) =>
+            header.toLowerCase() === `gyroraw[${axis}]`
+        ) ??
+        null;
+
+      return columnName
+        ? getColumnSamples(
+            lines,
+            telemetryHeaderIndex,
+            columnName
+          )
+        : [];
+    })
+    .filter((samples) => samples.length > 0);
+
+  if (axisSamples.length === 0) {
+    return null;
+  }
+
+  const totals = new Map();
+
+  for (const samples of axisSamples) {
+    for (const sample of samples) {
+      const value = Number(sample.value);
+
+      if (!Number.isFinite(value)) {
+        continue;
+      }
+
+      totals.set(
+        sample.rowIndex,
+        (totals.get(sample.rowIndex) ?? 0) + Math.abs(value)
+      );
+    }
+  }
+
+  return totals;
+})();
+
 const governorLabSamples = headspeedSamples
   .map((sample) => ({
     timeSeconds: timeByRow.get(sample.rowIndex),
     measuredRpm: sample.value,
-    targetRpm: governorTargetByRow.get(sample.rowIndex)
+    targetRpm: governorTargetByRow.get(sample.rowIndex),
+    activity: gyroActivityByRow
+      ? gyroActivityByRow.get(sample.rowIndex) ?? 0
+      : null
   }))
   .filter(
     (sample) =>
@@ -451,7 +505,10 @@ const governorLabAnalysis = analyzeGovernorLab({
       ? governorLabSamples.map(
           (sample) => sample.targetRpm
         )
-      : []
+      : [],
+  activity: gyroActivityByRow
+    ? governorLabSamples.map((sample) => sample.activity)
+    : []
 });
       flightAnalysis = buildFlightAnalysis(
         averageEscOutput,

--- a/src/analysis/logFileReader.js
+++ b/src/analysis/logFileReader.js
@@ -53,15 +53,29 @@ export async function readLogFile(file) {
 
     const usable = flights
       .filter((flight) => flight.mainFrames.length > 0)
-      .map((flight) => ({
-        label:
-          flights.length > 1
-            ? `Flight ${flight.index + 1} (${flight.durationSeconds.toFixed(1)} s)`
-            : "Flight 1",
-        lines: decodedFlightToCsvLines(flight),
-        decodeInfo: describeDecode(flight),
-        stats: flight.stats
-      }));
+      .map((flight) => {
+        // Converting every flight in an "all flights" download
+        // up front makes the wait scale with the whole file, so
+        // each flight builds its rows the first time it is read
+        // and keeps them afterwards.
+        let cachedLines = null;
+
+        return {
+          label:
+            flights.length > 1
+              ? `Flight ${flight.index + 1} (${flight.durationSeconds.toFixed(1)} s)`
+              : "Flight 1",
+          get lines() {
+            if (cachedLines === null) {
+              cachedLines = decodedFlightToCsvLines(flight);
+            }
+
+            return cachedLines;
+          },
+          decodeInfo: describeDecode(flight),
+          stats: flight.stats
+        };
+      });
 
     return {
       file,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1143,7 +1143,9 @@ function renderVerdict(dataset) {
   }
 
   verdictCard.hidden = false;
-  verdictSummary.textContent = verdict.summary;
+  verdictSummary.textContent = currentFlightSummary
+    ? `${currentFlightSummary} — ${verdict.summary}`
+    : verdict.summary;
   verdictCards.innerHTML = "";
 
   for (const card of verdict.cards) {
@@ -2315,12 +2317,20 @@ function renderFilterProfileBreakdown(dataset) {
 
 let currentDataset = null;
 let currentFlightLines = null;
+let currentFlightSummary = "";
 
 function analyzeFlight(flightIndex) {
   const flight = loadedLog.flights[flightIndex];
   const { file, sizeKb, fileType } = loadedLog;
   const lines = flight.lines;
   currentFlightLines = lines;
+
+  // A file holding several flights should never leave any doubt
+  // about which one the verdict describes.
+  currentFlightSummary =
+    loadedLog.flights.length > 1
+      ? `${flight.label} of ${loadedLog.flights.length}`
+      : "";
 
   decodeInfo.textContent = flight.decodeInfo
     ? `Binary .bbl decoded natively — ${flight.decodeInfo}`
@@ -2524,7 +2534,23 @@ async function datasetFromLogFile(file) {
     return null;
   }
 
-  const lines = logData.flights[0].lines;
+  // An "all flights" download holds several flights. Comparing
+  // against whichever happened to be recorded first is rarely
+  // what was meant, so the longest flight is used and the name
+  // says which one it was.
+  const frameCount = (flight) =>
+    (flight.stats?.intraFrames ?? 0) +
+    (flight.stats?.interFrames ?? 0);
+
+  const chosenFlight =
+    logData.flights.length > 1
+      ? [...logData.flights].sort(
+          (first, second) =>
+            frameCount(second) - frameCount(first)
+        )[0]
+      : logData.flights[0];
+
+  const lines = chosenFlight.lines;
 
   const { pidAnalysis } = buildLogAnalysis({
     fileType: logData.fileType,
@@ -2532,7 +2558,12 @@ async function datasetFromLogFile(file) {
     aircraftProfiles
   });
 
-  return { dataset: buildDataset(lines, pidAnalysis), name: file.name };
+  const name =
+    logData.flights.length > 1
+      ? `${file.name} — ${chosenFlight.label}`
+      : file.name;
+
+  return { dataset: buildDataset(lines, pidAnalysis), name };
 }
 
 function refreshCompareButtons() {

--- a/test/flightPhaseNoRotorSpeed.test.mjs
+++ b/test/flightPhaseNoRotorSpeed.test.mjs
@@ -1,0 +1,137 @@
+// ======================================================
+// FLIGHT PHASE — LOGS WITHOUT ROTOR SPEED
+// ======================================================
+//
+// Nitro and turbine models, and electric models flown
+// without the RPM sensor wired, log headspeed as a
+// constant zero. These tests cover how the shared phase
+// detector behaves for those logs.
+//
+// ======================================================
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  detectStableFlightPhase,
+  hasUsableRotorSpeed
+} from "../src/analysis/flightPhase.js";
+
+const SAMPLE_RATE = 1000;
+const DURATION_SECONDS = 60;
+const SAMPLE_COUNT = SAMPLE_RATE * DURATION_SECONDS;
+
+function buildTimeSeconds() {
+  return Array.from(
+    { length: SAMPLE_COUNT },
+    (_, index) => index / SAMPLE_RATE
+  );
+}
+
+// Deterministic stand-in for sensor noise, so the tests
+// never depend on a random seed.
+function wobble(index, amplitude) {
+  return (
+    Math.sin(index * 0.37) * amplitude +
+    Math.cos(index * 1.13) * amplitude * 0.5
+  );
+}
+
+test("rotor speed is recognised when it is present", () => {
+  assert.equal(hasUsableRotorSpeed([0, 0, 1800, 1805]), true);
+  assert.equal(hasUsableRotorSpeed([0, 0, 0, 0]), false);
+  assert.equal(hasUsableRotorSpeed([]), false);
+  assert.equal(hasUsableRotorSpeed(null), false);
+});
+
+test("a governed log still uses rotor speed as the basis", () => {
+  const timeSeconds = buildTimeSeconds();
+
+  const headspeed = timeSeconds.map((_, index) =>
+    1800 + wobble(index, 4)
+  );
+
+  const phase = detectStableFlightPhase({
+    timeSeconds,
+    headspeed,
+    governorTarget: timeSeconds.map(() => 1800)
+  });
+
+  assert.equal(phase.basis, "headspeed");
+  assert.equal(phase.hasRotorSpeedData, true);
+  assert.ok(phase.stableSampleCount > 0);
+});
+
+test("a log with no rotor speed and no motion signal says so", () => {
+  const timeSeconds = buildTimeSeconds();
+
+  const phase = detectStableFlightPhase({
+    timeSeconds,
+    headspeed: timeSeconds.map(() => 0),
+    governorTarget: []
+  });
+
+  assert.equal(phase.basis, "none");
+  assert.equal(phase.hasRotorSpeedData, false);
+  assert.equal(phase.stableSampleCount, 0);
+  assert.match(phase.reason, /no rotor-speed data/i);
+});
+
+test("a flown log with no rotor speed falls back to airframe motion", () => {
+  const timeSeconds = buildTimeSeconds();
+
+  // On the ground until 8 s, flying until 52 s, then down.
+  const activity = timeSeconds.map((time, index) => {
+    const airborne = time > 8 && time < 52;
+
+    return airborne
+      ? 140 + wobble(index, 20)
+      : 2 + Math.abs(wobble(index, 1));
+  });
+
+  const phase = detectStableFlightPhase({
+    timeSeconds,
+    headspeed: timeSeconds.map(() => 0),
+    governorTarget: [],
+    activity
+  });
+
+  assert.equal(phase.basis, "activity");
+  assert.equal(phase.hasRotorSpeedData, false);
+  assert.equal(phase.movedDuringRecording, true);
+  assert.ok(phase.segments.length >= 1);
+
+  const segment = phase.segments[0];
+
+  // The window sits inside the flight, clear of spool-up
+  // and spool-down.
+  assert.ok(timeSeconds[segment.startIndex] >= 8);
+  assert.ok(timeSeconds[segment.endIndex] <= 52);
+});
+
+test("a bench run with no rotor speed is not mistaken for flight", () => {
+  const timeSeconds = buildTimeSeconds();
+
+  // Servos and throttle move, the airframe does not: gyro
+  // noise only, with a quieter and a busier half so that
+  // contrast alone would form a ratio.
+  const activity = timeSeconds.map((time, index) => {
+    const busier = time > 25;
+
+    return (
+      (busier ? 1.4 : 0.4) + Math.abs(wobble(index, busier ? 0.6 : 0.2))
+    );
+  });
+
+  const phase = detectStableFlightPhase({
+    timeSeconds,
+    headspeed: timeSeconds.map(() => 0),
+    governorTarget: [],
+    activity
+  });
+
+  assert.equal(phase.basis, "none");
+  assert.equal(phase.movedDuringRecording, false);
+  assert.equal(phase.stableSampleCount, 0);
+  assert.match(phase.reason, /did not move/i);
+});


### PR DESCRIPTION
Closes #28. Addresses #27.

Two changes, one commit each, so they can be reviewed and reverted separately.

---

## 1. Logs recorded without an RPM sensor — #27

Nitro and turbine models, and electric models flown without the RPM sensor wired, record `headspeed` as a constant zero.

The shared flight-phase detector looks for steady **governed** flight, which is defined against rotor speed. With no rotor speed there are no samples to find, and every analysis built on that window — governor, ESC, battery and the filter/vibration work — reported that no stable section was long enough. That wording points at the flight, when what is actually missing is the sensor.

`detectStableFlightPhase()` now reports what it had to work with:

| field | meaning |
|---|---|
| `hasRotorSpeedData` | whether headspeed was ever recorded |
| `basis` | which signal defined the window: `headspeed`, `activity`, or `none` |
| `movedDuringRecording` | whether the airframe moved at all |

Where no rotor speed exists, an optional **airframe-motion signal** (gyro) can define the flight window instead, so filter and vibration analysis still runs on these logs. Where rotor speed is present, nothing changes — the existing path is untouched and still the default.

One detail worth knowing about, because it is what makes the fallback trustworthy: a model sitting on the ground still logs gyro noise, and a quieter half against a busier half will always form a ratio. So contrast alone is not accepted as flight — the busy end must also clear a floor of real rotation. That floor is set far below any flying model, so gentle hovering still qualifies.

Governor and battery now say which of the three situations applies, and the verdict cards explain it in plain language instead of implying the flight was too short or too unsteady.

**About the log attached to #27:** it decodes cleanly — 38,399 frames over 38.6 s, 36 corrupt frames skipped — so reading it was never the problem. It records no rotor speed, and the gyro stays within ±9 counts on every axis with attitude effectively constant, while the servos and throttle move throughout. That combination is a ground or bench run rather than a flight, so there is genuinely nothing there to score. After this change the app says that in as many words, rather than reporting that a section was not long enough. A log recorded in the air from the same model will now go through the motion-based path and produce filter and vibration results.

**Not included:** PID tracking still needs rotor speed, because its analysis rows come from the per-headspeed profiles. Giving it a motion-derived window is a natural follow-up but touches the profile labelling used across the PID Lab UI, so it is better as its own change than folded in here.

## 2. Multi-flight ("all flights") logs — #28

These files already decode and list correctly. Three places did not carry the fact that the file holds more than one flight:

- **The verdict now names its subject** — `Flight 2 (142.6 s) of 4`. The first flight in a dataflash download is usually the oldest, often a bench spool-up rather than the flight the pilot came to look at, so a confident plain-language verdict should never be read against the wrong one.
- **Compare Flights** reads whichever flight is longest rather than whichever was recorded first, and names it alongside the file, so both sides of a comparison are identifiable.
- **Flight rows are built when a flight is first opened** rather than for every flight at load, so opening a large download no longer scales the wait with the number of flights inside it.

The optional idea from #28 — defaulting the Home screen to the longest flight instead of the first — is deliberately **not** included, since that is a product call rather than a technical one. Everything here leaves that choice open.

---

## Testing

- `npm test` — 67 tests, all passing (66 pass, 1 pre-existing skip). Five are new, covering the governed case, a log with no rotor speed and no motion signal, a flown log without rotor speed, and a bench run whose noise would otherwise form a convincing ratio.
- Verified end to end against the log attached to #27.
- Verified the motion fallback finds the right window on a constructed no-rotor-speed flight: flight from 8 s to 52 s, window selected 10.7 s to 49.2 s, correctly clear of spool-up and spool-down.

Happy to adjust any of the wording on the verdict cards — that is your voice, and I have tried to match it.
