### PR TITLE
Connect log sharing to the decoded flight (for v0.3.8)

### DIFF
--- a/src/analysis/logFileReader.js
+++ b/src/analysis/logFileReader.js
@@ -65,6 +65,11 @@ export async function readLogFile(file) {
             flights.length > 1
               ? `Flight ${flight.index + 1} (${flight.durationSeconds.toFixed(1)} s)`
               : "Flight 1",
+          // The decoded flight, kept alongside the CSV-shaped
+          // rows. "Share anonymized logs" builds its payload
+          // from decoded frames and headers, so it needs the
+          // flight itself rather than the rows derived from it.
+          decoded: flight,
           get lines() {
             if (cachedLines === null) {
               cachedLines = decodedFlightToCsvLines(flight);

--- a/src/contribute/config.js
+++ b/src/contribute/config.js
@@ -11,5 +11,8 @@ export const CONTRIBUTE_ENDPOINT =
   "https://blackbox-ingest.dlsinkjr22.workers.dev/";
 
 // Reported inside the payload so contributed logs can be
-// grouped by app version. Update alongside package.json.
-export const CONTRIBUTE_APP_VERSION = "0.3.2";
+// grouped by app version. Taken from the app's own version
+// so the two can never drift apart.
+import { APP_VERSION } from "../version.js";
+
+export const CONTRIBUTE_APP_VERSION = APP_VERSION;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2440,12 +2440,18 @@ function analyzeFlight(flightIndex) {
   compareChartCard.hidden = true;
 
   // ---- community data sharing (opt-in, anonymized) ----
-  if (flight.mainFrames) {
+  // Text exports carry no decoded flight, so they skip this
+  // and sharing stays native-.bbl only.
+  if (flight.decoded) {
     // Bundled sample flights are shipped data — everyone has
     // them, so contributing them would only fill the community
     // bucket with identical copies.
     if (!file.name.startsWith("sample-")) {
-      maybeContributeFlight(flight, fileType, `${file.name}#${flightIndex}`);
+      maybeContributeFlight(
+        flight.decoded,
+        fileType,
+        `${file.name}#${flightIndex}`
+      );
     }
   }
 

--- a/test/contributionWiring.test.mjs
+++ b/test/contributionWiring.test.mjs
@@ -1,0 +1,99 @@
+// ======================================================
+// CONTRIBUTION WIRING — READER TO BUILDER
+// ======================================================
+//
+// contribution.test.mjs covers what the payload may and
+// may not contain, using a hand-built flight. These tests
+// cover the seam either side of it: that the log reader
+// hands out something the contribution builder can
+// actually consume, for a real file, end to end.
+//
+// ======================================================
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readLogFile } from "../src/analysis/logFileReader.js";
+import { buildContribution } from "../src/contribute/contributionBuilder.js";
+import { CONTRIBUTE_APP_VERSION } from "../src/contribute/config.js";
+import { APP_VERSION } from "../src/version.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const SAMPLE_PATH = path.join(
+  here,
+  "..",
+  "samples",
+  "sample-clean-tuned.bbl"
+);
+
+const ALL_ON = { power: true, gps: true, setup: true };
+
+async function readSample() {
+  const bytes = fs.readFileSync(SAMPLE_PATH);
+
+  return readLogFile(
+    new File([bytes], path.basename(SAMPLE_PATH))
+  );
+}
+
+test("the reader hands out the decoded flight, not only its rows", async () => {
+  const logData = await readSample();
+
+  assert.ok(logData.flights.length > 0, "expected at least one flight");
+
+  const flight = logData.flights[0];
+
+  assert.ok(
+    flight.decoded,
+    "each flight must carry its decoded form for sharing"
+  );
+
+  assert.ok(
+    Array.isArray(flight.decoded.mainFrames) &&
+      flight.decoded.mainFrames.length > 0,
+    "the decoded flight must still hold its frames"
+  );
+
+  assert.ok(
+    Array.isArray(flight.decoded.mainFieldNames) &&
+      flight.decoded.mainFieldNames.length > 0,
+    "the decoded flight must still hold its field names"
+  );
+});
+
+test("what the reader hands out is what the builder consumes", async () => {
+  const logData = await readSample();
+
+  const payload = buildContribution(
+    logData.flights[0].decoded,
+    logData.fileType,
+    ALL_ON,
+    CONTRIBUTE_APP_VERSION
+  );
+
+  assert.ok(payload, "a payload was expected");
+
+  assert.ok(
+    Array.isArray(payload.fields) && payload.fields.length > 0,
+    "payload should name the fields it carries"
+  );
+
+  assert.ok(
+    Array.isArray(payload.frames) && payload.frames.length > 0,
+    "payload should carry frames — an empty one would upload nothing useful"
+  );
+
+  assert.equal(
+    payload.frames[0].length,
+    payload.fields.length,
+    "every frame should line up with the field list"
+  );
+});
+
+test("contributions are labelled with the running app version", () => {
+  assert.equal(CONTRIBUTE_APP_VERSION, APP_VERSION);
+});


### PR DESCRIPTION
## What it does

`contributionBuilder` assembles its payload from a **decoded** flight: it reads `headers`, `mainFieldNames`, `mainFrames`, `slowFrames` and `gpsFrames`.

`readLogFile()` returns each flight as `{ label, lines, decodeInfo, stats }` — the CSV-shaped view every analysis module consumes. That view is derived from the decoded flight but does not include it, so at the point where a contribution is assembled the decoded flight was not in reach.

The reader now carries the decoded flight alongside those rows, and the renderer hands that to the builder:

```js
// logFileReader.js
decoded: flight,

// renderer.js
if (flight.decoded) {
  maybeContributeFlight(flight.decoded, fileType, key);
}
```

Text and CSV exports have no decoded flight, so they skip the branch and sharing stays native-`.bbl` only, exactly as before. Nothing about the opt-in, the category allowlist, or the payload contents changes.

## Version labelling

`CONTRIBUTE_APP_VERSION` now derives from `APP_VERSION` instead of being a second copy of the number:

```js
import { APP_VERSION } from "../version.js";
export const CONTRIBUTE_APP_VERSION = APP_VERSION;
```

Contributed logs are grouped by app version, so this keeps that label tracking the build that produced them without a second thing to remember at release time.

## Tests

`test/contribution.test.mjs` already covers what a payload may and may not contain, using a hand-built flight — the privacy properties are well covered there and untouched by this.

The three new tests in `test/contributionWiring.test.mjs` cover the seam on either side of it, with a real file:

- the reader hands out a decoded flight that still holds its frames and field names
- `samples/sample-clean-tuned.bbl` flows reader → builder and produces a populated payload whose frames line up with its field list
- the reported version tracks the app version
