### PR TITLE
Compare Flights: choose which flight of a multi-flight file is the "after"

### DIFF
--- a/src/analysis/flightSelection.js
+++ b/src/analysis/flightSelection.js
@@ -1,0 +1,37 @@
+// ======================================================
+// BLACKBOX LAB — FLIGHT SELECTION
+// ======================================================
+//
+// Helpers for choosing a flight out of a multi-flight
+// ("Save All Logs") file. The default pick — the longest
+// flight — is what Compare Flights always assumed; making
+// it a named, tested function lets the comparison flight
+// picker preselect the same choice the app used to make
+// silently.
+//
+// ======================================================
+
+export function frameCountOf(flight) {
+  return (
+    (flight?.stats?.intraFrames ?? 0) +
+    (flight?.stats?.interFrames ?? 0)
+  );
+}
+
+// The longest flight of the file — by decoded frames, so a
+// half-written last session never outranks a real flight.
+export function longestFlightIndex(flights) {
+  if (!Array.isArray(flights) || flights.length === 0) {
+    return 0;
+  }
+
+  let best = 0;
+
+  for (let index = 1; index < flights.length; index += 1) {
+    if (frameCountOf(flights[index]) > frameCountOf(flights[best])) {
+      best = index;
+    }
+  }
+
+  return best;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -748,6 +748,14 @@ current demand; the steady downward slope is normal discharge.
               Demo: compare with the clean sample
             </button>
           </div>
+
+          <!-- Shown when the "after" file holds several flights:
+               pick which one to compare against. Preselected on
+               the longest flight; switching re-compares. -->
+          <div class="flight-picker" id="compareFlightPicker" hidden>
+            <span class="label">"After" flight in this file</span>
+            <select id="compareFlightSelect"></select>
+          </div>
         </section>
 
         <section class="card" id="compareResultCard" hidden>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -34,6 +34,7 @@ import {
 } from "./analysis/flightPhase.js";
 import { buildFlightVerdict } from "./analysis/flightVerdict.js";
 import { compareFlights } from "./analysis/compareFlights.js";
+import { longestFlightIndex } from "./analysis/flightSelection.js";
 import { assessLogQuality } from "./analysis/logQuality.js";
 import { adviseFilters } from "./analysis/filterAdvisor.js";
 import {
@@ -169,6 +170,8 @@ const compareBaselineInfo = el("compareBaselineInfo");
 const compareOpenButton = el("compareOpenButton");
 const compareSampleButton = el("compareSampleButton");
 const compareFileInput = el("compareFileInput");
+const compareFlightPicker = el("compareFlightPicker");
+const compareFlightSelect = el("compareFlightSelect");
 const compareResultCard = el("compareResultCard");
 const compareChartCard = el("compareChartCard");
 const compareSummary = el("compareSummary");
@@ -2533,43 +2536,68 @@ function strongestSpectrumOf(dataset) {
   return strongest.spectrum;
 }
 
-async function datasetFromLogFile(file) {
+// The loaded "after" log. Kept around so the flight picker
+// can re-compare against any flight in the file without
+// re-reading it; datasets build lazily, once per flight.
+let comparisonLog = null;
+
+function datasetForComparisonFlight(flightIndex) {
+  const { logData, datasets } = comparisonLog;
+
+  if (!datasets.has(flightIndex)) {
+    const flight = logData.flights[flightIndex];
+    const lines = flight.lines;
+
+    const { pidAnalysis } = buildLogAnalysis({
+      fileType: logData.fileType,
+      lines,
+      aircraftProfiles
+    });
+
+    const name =
+      logData.flights.length > 1
+        ? `${logData.file.name} — ${flight.label}`
+        : logData.file.name;
+
+    datasets.set(flightIndex, {
+      dataset: buildDataset(lines, pidAnalysis),
+      name
+    });
+  }
+
+  return datasets.get(flightIndex);
+}
+
+// Load a file as the "after" side of the comparison. An
+// "all flights" download holds several flights: the picker
+// appears, preselected on the longest flight (the choice
+// the app used to make silently), and switching it
+// re-compares against that flight — so two flights of the
+// SAME file can be compared without splitting the file.
+async function loadComparisonFile(file) {
   const logData = await readLogFile(file);
 
   if (!logData || logData.flights.length === 0) {
+    comparisonLog = null;
+    compareFlightPicker.hidden = true;
     return null;
   }
 
-  // An "all flights" download holds several flights. Comparing
-  // against whichever happened to be recorded first is rarely
-  // what was meant, so the longest flight is used and the name
-  // says which one it was.
-  const frameCount = (flight) =>
-    (flight.stats?.intraFrames ?? 0) +
-    (flight.stats?.interFrames ?? 0);
+  comparisonLog = { logData, datasets: new Map() };
 
-  const chosenFlight =
-    logData.flights.length > 1
-      ? [...logData.flights].sort(
-          (first, second) =>
-            frameCount(second) - frameCount(first)
-        )[0]
-      : logData.flights[0];
+  const defaultIndex = longestFlightIndex(logData.flights);
 
-  const lines = chosenFlight.lines;
-
-  const { pidAnalysis } = buildLogAnalysis({
-    fileType: logData.fileType,
-    lines,
-    aircraftProfiles
+  compareFlightSelect.innerHTML = "";
+  logData.flights.forEach((flight, index) => {
+    const option = document.createElement("option");
+    option.value = String(index);
+    option.textContent = flight.label;
+    compareFlightSelect.appendChild(option);
   });
+  compareFlightSelect.value = String(defaultIndex);
+  compareFlightPicker.hidden = logData.flights.length < 2;
 
-  const name =
-    logData.flights.length > 1
-      ? `${file.name} — ${chosenFlight.label}`
-      : file.name;
-
-  return { dataset: buildDataset(lines, pidAnalysis), name };
+  return datasetForComparisonFlight(defaultIndex);
 }
 
 function refreshCompareButtons() {
@@ -2645,7 +2673,7 @@ compareFileInput.addEventListener("change", async () => {
   }
 
   try {
-    const result = await datasetFromLogFile(file);
+    const result = await loadComparisonFile(file);
 
     if (result && result.dataset) {
       renderComparison(result.dataset, result.name);
@@ -2659,6 +2687,19 @@ compareFileInput.addEventListener("change", async () => {
   }
 
   compareFileInput.value = "";
+});
+
+// Switching the picker re-compares on the spot — flipping
+// between two flights of one file is the whole point.
+compareFlightSelect.addEventListener("change", () => {
+  if (!comparisonLog) {
+    return;
+  }
+
+  const result = datasetForComparisonFlight(
+    Number(compareFlightSelect.value)
+  );
+  renderComparison(result.dataset, result.name);
 });
 
 compareSampleButton.addEventListener("click", async () => {
@@ -2675,7 +2716,7 @@ compareSampleButton.addEventListener("click", async () => {
     "sample-clean-tuned.bbl"
   );
 
-  const result = await datasetFromLogFile(file);
+  const result = await loadComparisonFile(file);
 
   if (result && result.dataset) {
     renderComparison(result.dataset, result.name);

--- a/test/flightSelection.test.mjs
+++ b/test/flightSelection.test.mjs
@@ -1,0 +1,61 @@
+// ======================================================
+// BLACKBOX LAB — FLIGHT SELECTION TESTS
+// ======================================================
+//
+// Run with:  npm test   (node --test)
+//
+// The comparison flight picker preselects the longest
+// flight of a multi-flight file — the same choice Compare
+// Flights used to make silently. These tests pin that
+// behavior down.
+//
+// ======================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  frameCountOf,
+  longestFlightIndex
+} from "../src/analysis/flightSelection.js";
+
+const flight = (intra, inter) => ({
+  stats: { intraFrames: intra, interFrames: inter }
+});
+
+test("frame count is intra plus inter frames", () => {
+  assert.equal(frameCountOf(flight(100, 900)), 1000);
+  assert.equal(frameCountOf({}), 0);
+  assert.equal(frameCountOf(null), 0);
+  assert.equal(frameCountOf({ stats: null }), 0);
+});
+
+test("the longest flight wins, not the first or last", () => {
+  const flights = [
+    flight(10, 90), // 100
+    flight(100, 4900), // 5000 — the real flight
+    flight(1, 9) // 10 — a half-written tail session
+  ];
+
+  assert.equal(longestFlightIndex(flights), 1);
+});
+
+test("ties keep the earlier flight; degenerate inputs pick 0", () => {
+  assert.equal(
+    longestFlightIndex([flight(50, 50), flight(60, 40)]),
+    0,
+    "equal totals should keep the first flight"
+  );
+  assert.equal(longestFlightIndex([]), 0);
+  assert.equal(longestFlightIndex(null), 0);
+  assert.equal(longestFlightIndex([flight(1, 1)]), 0);
+});
+
+test("flights without stats (text exports) never outrank decoded ones", () => {
+  const flights = [
+    { stats: null },
+    flight(100, 900)
+  ];
+
+  assert.equal(longestFlightIndex(flights), 1);
+});

--- a/tools/ui-smoke.cjs
+++ b/tools/ui-smoke.cjs
@@ -107,6 +107,58 @@ const { mkdirSync } = require("node:fs");
   console.log("compare rows:", compareRowCount, "| summary:", compareSummary);
   await window.screenshot({ path: "smoke-shots/08-compare.png" });
 
+  // ---- multi-flight "after" file: the flight picker ----
+  // Two known samples concatenated = one file, two flights.
+  const twoFlightPath = require("node:path").join(
+    require("node:os").tmpdir(),
+    "bbl-smoke-two-flights.bbl"
+  );
+  require("node:fs").writeFileSync(
+    twoFlightPath,
+    Buffer.concat([
+      require("node:fs").readFileSync("samples/sample-clean-tuned.bbl"),
+      require("node:fs").readFileSync("samples/sample-vibration-problem.bbl")
+    ])
+  );
+  await window.setInputFiles("#compareFileInput", twoFlightPath);
+  await window.waitForSelector("#compareFlightPicker:not([hidden])", {
+    timeout: 15000
+  });
+  const pickerState = await window.evaluate(() => ({
+    options: document.getElementById("compareFlightSelect").options.length,
+    selected: document.getElementById("compareFlightSelect").value,
+    summary: document.getElementById("compareSummary").textContent,
+    rows: document.getElementById("compareRows").innerText
+  }));
+  if (pickerState.options !== 2 || !pickerState.summary) {
+    throw new Error(
+      "compare flight picker misbehaved: " + JSON.stringify(pickerState)
+    );
+  }
+  // Flip to the other flight — the comparison must re-render
+  // with THAT flight's numbers (clean vs vibration sample, so
+  // the row values must actually change).
+  const otherFlight = pickerState.selected === "0" ? "1" : "0";
+  await window.selectOption("#compareFlightSelect", otherFlight);
+  await window.waitForTimeout(2500);
+  const flippedRows = await window.evaluate(
+    () => document.getElementById("compareRows").innerText
+  );
+  if (!flippedRows || flippedRows === pickerState.rows) {
+    throw new Error(
+      "comparison did not re-render with the picked flight's data"
+    );
+  }
+  console.log(
+    "compare flight picker ok:",
+    pickerState.options,
+    "flights | flipped to",
+    otherFlight,
+    "| rows changed:",
+    flippedRows !== pickerState.rows
+  );
+  await window.screenshot({ path: "smoke-shots/08b-compare-picker.png" });
+
   // ---- load-from-another-screen: progress dialog ----
   await window.click('.nav-button[data-target="viewer"]');
   await window.waitForTimeout(300);


### PR DESCRIPTION
Closes #31.

When the "after" log is an "all flights" download, Compare Flights now shows a flight picker (same style as the Home screen's) instead of silently using the longest flight. It starts on the longest flight — the same choice as before, so nothing changes until the pilot touches it — and switching flights re-compares immediately.

This also covers the case @eeeeivindH asked for: comparing two flights of the **same** file (e.g. flight 4 vs flight 5 of one session card) now works by opening that file as the "after" log and picking the flight — no file splitting needed.

Under the hood: the default pick lives in `src/analysis/flightSelection.js` with its own tests; per-flight comparison datasets are built lazily and cached, so flipping between flights of a big file is instant after the first look. The UI smoke run now drives the picker with a two-flight file and asserts the comparison genuinely re-renders. 74 tests green.

Merging from the browser: the green **Merge pull request** button is all it takes — no release needed for this one; it rides along with whatever ships next.