### PR TITLE
macOS: per-architecture first-launch instructions

### DIFF
--- a/Documentation/RELEASING.md
+++ b/Documentation/RELEASING.md
@@ -51,9 +51,19 @@ all, so pilots pick the one matching their machine — **About This
 Mac** tells them which: "Apple M…" means Apple Silicon, "Intel Core…"
 means Intel.
 
-Neither Mac build is code-signed, so the first launch needs
-**right-click → Open** rather than a double-click. That is normal for
-free unsigned apps and only has to be done once.
+Neither Mac build is code-signed, and macOS quarantines unsigned
+downloads. What pilots see depends on their machine, and both cases
+are normal for free unsigned apps, needed only once:
+
+- **Apple Silicon** shows *"Blackbox Lab is damaged and can't be
+  opened"*. The download is fine — clearing the quarantine flag in
+  Terminal makes it open normally:
+  `xattr -cr "/Applications/Blackbox Lab.app"`
+- **Intel** Macs usually just need **right-click → Open** on the
+  first launch.
+
+The README's Download section carries the same instructions for
+pilots.
 
 ## If something goes wrong
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,21 @@ Ready-made installers for **Windows, macOS and Linux** are on the
 
 macOS comes in two builds: `darwin-arm64` for Apple Silicon (M1 and
 newer) and `darwin-x64` for Intel Macs. **About This Mac** tells you
-which you have. Neither is code-signed, so open the app the first
-time with right-click → Open.
+which you have.
+
+Because the app is not signed with a paid Apple developer
+certificate, macOS quarantines it after download. On **Apple
+Silicon** this shows up as *"Blackbox Lab is damaged and can't be
+opened"* — the download is fine; that message is just macOS being
+protective about unsigned apps. Clear the quarantine flag once and
+it opens normally from then on. In Terminal:
+
+```
+xattr -cr "/Applications/Blackbox Lab.app"
+```
+
+(Adjust the path if you keep the app somewhere else.) On **Intel**
+Macs, right-click → Open on first launch is usually all it takes.
 
 ---
 


### PR DESCRIPTION
macOS treats unsigned downloads differently depending on the machine: Intel Macs offer the right-click → Open path, while Apple Silicon shows *"Blackbox Lab is damaged and can't be opened"* — scary wording for what is just the quarantine flag on an unsigned app. The download itself is fine.

The README's Download section and `Documentation/RELEASING.md` now give each architecture the step that actually works:

- **Apple Silicon** (M1 and newer): one Terminal command, needed once — `xattr -cr "/Applications/Blackbox Lab.app"` — and the app opens normally from then on.
- **Intel**: right-click → Open on first launch, as before.

Docs only, no code changes — the green **Merge pull request** button is all it takes, and the new wording is immediately live on the repo front page for anyone hitting this today.

The lasting fix would be Developer ID signing + notarization, which needs an Apple Developer membership — happy to wire the release workflow for it whenever that's on the table.